### PR TITLE
Only activate macro on intended scene

### DIFF
--- a/OBS Script/advanced_scene_switcher_obs.json
+++ b/OBS Script/advanced_scene_switcher_obs.json
@@ -79,6 +79,34 @@
                         "version": 1
                     },
                     "version": 0
+                },
+                {
+                    "segmentSettings": {
+                        "collapsed": false,
+                        "useCustomLabel": false,
+                        "customLabel": "My label"
+                    },
+                    "id": "scene",
+                    "logic": 101,
+                    "durationModifier": {
+                        "time_constraint": 0,
+                        "seconds": {
+                            "value": {
+                                "value": 0.0,
+                                "type": 0
+                            },
+                            "unit": 0,
+                            "version": 1
+                        }
+                    },
+                    "sceneSelection": {
+                        "type": 0,
+                        "name": "DJ Ichiban"
+                    },
+                    "type": 10,
+                    "pattern": ".*Scene.*",
+                    "useTransitionTargetScene": false,
+                    "version": 1
                 }
             ],
         "actions": [

--- a/OBS Script/shizu_obs_hijack_script.py
+++ b/OBS Script/shizu_obs_hijack_script.py
@@ -529,6 +529,7 @@ class AdvancedSceneSwitchManager:
                 action["actions"][0]["sceneSelection"]["name"] = S.obs_source_get_name(S.obs_scene_get_source(ending_scene))
             # Set conditional media to switch on end
             action["conditions"][0]["source"]["name"] = dj[3]
+            action["conditions"][1]["sceneSelection"]["name"] = dj[1]
             actions.append(action)
             print(f"Added {dj[0]} pointing to scene {action['actions'][0]['sceneSelection']['name']}")
         
@@ -537,6 +538,7 @@ class AdvancedSceneSwitchManager:
             promos_action["name"] = "switch_from_promos"
             promos_action["actions"][0]["sceneSelection"]["name"] = S.obs_source_get_name(S.obs_scene_get_source(ending_scene))
             promos_action["conditions"][0]["source"]["name"] = "promo_videos"
+            promos_action["conditions"][1]["sceneSelection"]["name"] = S.obs_source_get_name(S.obs_scene_get_source(promos_scene))
             actions.append(promos_action)
 
         return json.dumps({


### PR DESCRIPTION
Adds a new condition to each macro, checking if the media end occurred while the media's scene is currently active. This prevents unintended cascade macro activations when testing an inactive scene.