### PR TITLE
Add PG Migrations

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -205,16 +205,11 @@ export const create_tables = async () => {
   const client = database_client();
   await run_migrations(client);
 
-  // await client.connect();
+  // Initial theme values for GUI
+  const themes = await client.query(`SELECT * FROM ${APP_THEMES_TABLE.name};`);
+  if (themes.rows.length === 0) await initial_data();
 
-  // for (const table of ALL_TABLES) {
-  //   await internal_create_table_helper(client, table);
-  // }
-
-  // const themes = await client.query(`SELECT * FROM ${APP_THEMES_TABLE.name};`);
-  // if (themes.rows.length === 0) await initial_data();
-
-  // await client.end();
+  await client.end();
 };
 
 const initial_data = async () => {

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -83,6 +83,7 @@ import {
   internal_insert_into_app_themes,
   internal_update_app_themes,
 } from "./database_helpers/app_themes_db_helpers";
+import { run_migrations } from "./db_migrations/migrations";
 
 // File for accessing SQL, handles client/pool lifecycles.
 
@@ -202,16 +203,18 @@ export const get_app_theme = async (name: string) => {
 
 export const create_tables = async () => {
   const client = database_client();
-  await client.connect();
+  await run_migrations(client);
 
-  for (const table of ALL_TABLES) {
-    await internal_create_table_helper(client, table);
-  }
+  // await client.connect();
 
-  const themes = await client.query(`SELECT * FROM ${APP_THEMES_TABLE.name};`);
-  if (themes.rows.length === 0) await initial_data();
+  // for (const table of ALL_TABLES) {
+  //   await internal_create_table_helper(client, table);
+  // }
 
-  await client.end();
+  // const themes = await client.query(`SELECT * FROM ${APP_THEMES_TABLE.name};`);
+  // if (themes.rows.length === 0) await initial_data();
+
+  // await client.end();
 };
 
 const initial_data = async () => {

--- a/backend/src/db_migrations/initial_tables.ts
+++ b/backend/src/db_migrations/initial_tables.ts
@@ -1,57 +1,16 @@
-import { IColumnDefinition } from "./types";
+import {
+  Table,
+  DJS_TABLE_NAME,
+  PROMOS_TABLE_NAME,
+  EVENTS_TABLE_NAME,
+  THEMES_TABLE_NAME,
+  FILES_TABLE_NAME,
+  APP_THEMES_TABLE_NAME,
+} from "../tables";
 
-// SQL Tables class, defines table schema and has simple boilerplate query generation.
-// With the introduction of migrations, these definitions are for the post-migration states.
+// Initial table definitions before any migrations
 
-// Boilderplate query generator
-export class Table {
-  name: string;
-  definitions: IColumnDefinition[];
-  columns: string[];
-  constructor(name: string, definitions: IColumnDefinition[]) {
-    this.name = name;
-    this.definitions = definitions;
-    this.columns = definitions.map((col) => col.name);
-  }
-
-  private definitions_to_string = () => {
-    const def_strings = this.definitions.map((def) => {
-      if (def.fkey) {
-        return `${def.name} ${def.type} references ${def.fkey}`;
-      }
-      return `${def.name} ${def.type}`;
-    });
-    return def_strings.join(", ");
-  };
-
-  public create_table() {
-    return `CREATE TABLE IF NOT EXISTS "${this.name}" (${this.definitions_to_string()});`;
-  }
-
-  public exists() {
-    return `SELECT 1 FROM pg_tables WHERE tablename = '${this.name}';`;
-  }
-
-  public select() {
-    return `SELECT * FROM ${this.name};`;
-  }
-
-  public get_single(primary_key: string) {
-    return `SELECT * FROM ${this.name} WHERE ${this.columns[0]} = '${primary_key}';`;
-  }
-
-  public insert_into(values: string) {
-    return `INSERT INTO ${this.name} VALUES ${values};`;
-  }
-}
-
-export const DJS_TABLE_NAME = "djs";
-export const PROMOS_TABLE_NAME = "promos";
-export const EVENTS_TABLE_NAME = "events";
-export const THEMES_TABLE_NAME = "themes";
-export const FILES_TABLE_NAME = "files";
-export const APP_THEMES_TABLE_NAME = "app_themes";
-export const DJS_TABLE: Table = new Table(DJS_TABLE_NAME, [
+export const DJS_TABLE_0: Table = new Table(DJS_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
@@ -87,7 +46,7 @@ export const DJS_TABLE: Table = new Table(DJS_TABLE_NAME, [
     type: "TEXT[]",
   },
 ]);
-export const PROMOS_TABLE: Table = new Table(PROMOS_TABLE_NAME, [
+export const PROMOS_TABLE_0: Table = new Table(PROMOS_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
@@ -98,7 +57,7 @@ export const PROMOS_TABLE: Table = new Table(PROMOS_TABLE_NAME, [
     fkey: `${FILES_TABLE_NAME}(name)`,
   },
 ]);
-export const EVENTS_TABLE: Table = new Table(EVENTS_TABLE_NAME, [
+export const EVENTS_TABLE_0: Table = new Table(EVENTS_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
@@ -129,7 +88,7 @@ export const EVENTS_TABLE: Table = new Table(EVENTS_TABLE_NAME, [
     type: "BOOLEAN",
   },
 ]);
-export const THEMES_TABLE: Table = new Table(THEMES_TABLE_NAME, [
+export const THEMES_TABLE_0: Table = new Table(THEMES_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
@@ -146,11 +105,6 @@ export const THEMES_TABLE: Table = new Table(THEMES_TABLE_NAME, [
   },
   {
     name: "starting_file",
-    type: "TEXT",
-    fkey: `${FILES_TABLE_NAME}(name)`,
-  },
-  {
-    name: "starting_bgm_file",
     type: "TEXT",
     fkey: `${FILES_TABLE_NAME}(name)`,
   },
@@ -192,7 +146,7 @@ export const THEMES_TABLE: Table = new Table(THEMES_TABLE_NAME, [
     type: "SMALLINT",
   },
 ]);
-export const FILES_TABLE: Table = new Table(FILES_TABLE_NAME, [
+export const FILES_TABLE_0: Table = new Table(FILES_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
@@ -210,7 +164,7 @@ export const FILES_TABLE: Table = new Table(FILES_TABLE_NAME, [
     type: "TEXT",
   },
 ]);
-export const APP_THEMES_TABLE: Table = new Table(APP_THEMES_TABLE_NAME, [
+export const APP_THEMES_TABLE_0: Table = new Table(APP_THEMES_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
@@ -221,10 +175,10 @@ export const APP_THEMES_TABLE: Table = new Table(APP_THEMES_TABLE_NAME, [
   },
 ]);
 export const ALL_TABLES = [
-  FILES_TABLE,
-  THEMES_TABLE,
-  PROMOS_TABLE,
-  DJS_TABLE,
-  EVENTS_TABLE,
-  APP_THEMES_TABLE,
+  FILES_TABLE_0,
+  THEMES_TABLE_0,
+  PROMOS_TABLE_0,
+  DJS_TABLE_0,
+  EVENTS_TABLE_0,
+  APP_THEMES_TABLE_0,
 ];

--- a/backend/src/db_migrations/migrations.ts
+++ b/backend/src/db_migrations/migrations.ts
@@ -1,0 +1,54 @@
+import { Client } from "pg";
+import {
+  DJS_TABLE_0,
+  PROMOS_TABLE_0,
+  EVENTS_TABLE_0,
+  THEMES_TABLE_0,
+  FILES_TABLE_0,
+  APP_THEMES_TABLE_0,
+} from "./initial_tables";
+import { FILES_TABLE_NAME, THEMES_TABLE_NAME } from "../tables";
+
+// Create base version of all tables, if they don't exist.
+const initial_setup = async (client: Client) => {
+  console.log("Starting initial table setup.");
+  const initial_tables = [
+    DJS_TABLE_0,
+    PROMOS_TABLE_0,
+    EVENTS_TABLE_0,
+    THEMES_TABLE_0,
+    FILES_TABLE_0,
+    APP_THEMES_TABLE_0,
+  ];
+  for (const table of initial_tables) {
+    await client.query(table.create_table());
+  }
+  console.log("Completed initial table setup.");
+};
+
+// Introduce opening bgm
+const migration_1 = async (client: Client) => {
+  console.log("Starting migration 1.");
+  await client.query(
+    `ALTER TABLE "${THEMES_TABLE_NAME}" ADD COLUMN IF NOT EXISTS starting_bgm_file text references ${FILES_TABLE_NAME}(name);`,
+  );
+  console.log("Completed migration 1.");
+};
+
+export const run_migrations = async (client: Client) => {
+  client.connect();
+
+  try {
+    await client.query("BEGIN");
+    // Migrations go here
+    await initial_setup(client);
+    await migration_1(client);
+    // Commit transaction
+    await client.query("COMMIT");
+  } catch (e) {
+    // Rollback on error
+    await client.query("ROLLBACK");
+    await client.end();
+    throw e;
+  }
+};


### PR DESCRIPTION
Replaces the initial table creation logic with a migrations file, which will run through all preset migrations on startup. Migrations need to be idempotent to prevent any issues with running the whole suite on an already established db.

Since the table definitions are being built upon several migrations, the classes defined in tables.ts represent the final state of each table post-migration.