### PR TITLE
Encode permission checks

### DIFF
--- a/backend/openapi/schema.yaml
+++ b/backend/openapi/schema.yaml
@@ -721,7 +721,7 @@ paths:
       tags:
         - local-files
       summary: Returns a FileDialogBlob for logos at a given path
-      description: Used for navigating logo files on the server.
+      description: Used for navigating logo files on the server. Expects a string encoded with encodeURIComponent.
       parameters:
         - name: logoPath
           in: path
@@ -754,7 +754,7 @@ paths:
       tags:
         - local-files
       summary: Returns a FileDialogBlob for recordings at a given path
-      description: Used for navigating recording files on the server.
+      description: Used for navigating recording files on the server. Expects a string encoded with encodeURIComponent.
       parameters:
         - name: recordingPath
           in: path
@@ -787,7 +787,7 @@ paths:
       tags:
         - local-files
       summary: Returns a FileDialogBlob for themes at a given path
-      description: Used for navigating theme files on the server.
+      description: Used for navigating theme files on the server. Expects a string encoded with encodeURIComponent.
       parameters:
         - name: themePath
           in: path

--- a/backend/src/file_helpers.ts
+++ b/backend/src/file_helpers.ts
@@ -35,6 +35,7 @@ export const root_map = new Map([
 ]);
 
 export const getLocalLogoFiles = (sub_dirs: string[]) => {
+  console.log(sub_dirs);
   const new_path = join(LOGOS_ROOT, ...sub_dirs);
   const new_items = readdirSync(new_path, { withFileTypes: true });
 

--- a/backend/src/openapi_routers/file_router.ts
+++ b/backend/src/openapi_routers/file_router.ts
@@ -37,7 +37,8 @@ fileRouter.get("/logo-permissions", async (req, res) => {
 });
 
 fileRouter.get("/logo-permissions/:logoPath", async (req, res) => {
-  const file_blob = await getLocalLogoFiles(req.params.logoPath.split("/"));
+  const decoded_path = decodeURIComponent(req.params.logoPath);
+  const file_blob = await getLocalLogoFiles(decoded_path.split("/"));
   res.status(200);
   return res.send(file_blob);
 });
@@ -49,9 +50,8 @@ fileRouter.get("/recording-permissions", async (req, res) => {
 });
 
 fileRouter.get("/recording-permissions/:recordingPath", async (req, res) => {
-  const file_blob = await getLocalRecordingFiles(
-    req.params.recordingPath.split("/"),
-  );
+  const decoded_path = decodeURIComponent(req.params.recordingPath);
+  const file_blob = await getLocalRecordingFiles(decoded_path.split("/"));
   res.status(200);
   return res.send(file_blob);
 });
@@ -63,7 +63,8 @@ fileRouter.get("/theme-permissions", async (req, res) => {
 });
 
 fileRouter.get("/theme-permissions/:themePath", async (req, res) => {
-  const file_blob = await getLocalThemeFiles(req.params.themePath.split("/"));
+  const decoded_path = decodeURIComponent(req.params.themePath);
+  const file_blob = await getLocalThemeFiles(decoded_path.split("/"));
   res.status(200);
   return res.send(file_blob);
 });

--- a/frontend/src/lib/store.js
+++ b/frontend/src/lib/store.js
@@ -150,7 +150,7 @@ export const oaFetchFileExists = async (file) => {
 
 const filePermissionsHelper = (url, sub_dirs) => {
   if (sub_dirs.length > 0) {
-    url += "/" + sub_dirs.join("/");
+    url += "/" + encodeURIComponent(sub_dirs.join("/"));
   }
   console.log(url);
   return openapiGet(url);


### PR DESCRIPTION
Encodes permission path checks for GET calls, to play nice with how express' router handles params.