### PR TITLE
Event DJs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,12 @@ Changing the frontend image in `comopose.yaml` from `frontend-svelte-5` to `fron
 ## Volume Migration
 Due to the DB docker volume being configured improperly, after v0.1.2 the volume mount has been corrected to `/var/lib/postgresql/data`. In order to preserve data across this, before updating you will need to run the following steps:
 - Dump the current DB to the existing volume `/data/postgres`. `pg_dump -F c -d shizu_db -f /data/postgres/db.dump` should work.
-- Verify the `db.dump` file is present in your docker volume, then add another volume to the DB container in docker-compose which will be the temporary dir to keep this `db.dump`. 
-- Destroy and rebuild both image and container for db.
-- Copy your `db.dump` file from the old volume to the new one.
-- Change the original volume mount to `/var/lib/postgresql/data`, which is what it will point to in the future. Make sure the existing volume is empty
-- Destory and rebuild again.
-- You should now have 2 volumes, one being your temp volume with the `db.dump` file, and the other pointing to postgresql's data folder.
-- Run `pg_restore`, i.e `pg_restore -c -F c -d shizu_db /path/to/you/db.dump`
+- Verify the `db.dump` file is present in your docker volume, and save it to your host system.
+- Change the volume mount to `/var/lib/postgresql/data`, which is what it will point to in the future. Make sure the existing volume is empty.
+- Create a bind mount in the `db` image, `/data/postgres` or some other unused path is fine to mount to in the container.
+- Place `db.dump` into your bind mount, so that it is accesible from the rebuilt container.
+- Destory both image and container for db, and rebuild both.
+- Run `pg_restore`, i.e `pg_restore -c -F c -d shizu_db /path/to/your/db.dump`
 - Restart your backend container, and everything should be correctly restored from before the change.
 - Continue updating the software as instructed through `git pull` or copy release data.
 

--- a/Walkthrough.md
+++ b/Walkthrough.md
@@ -4,113 +4,13 @@
 
 Not referring to installation (check the [README](/README.md) for that).
 
-This section is for interracting with the GUI to setup and export an event, [Usage](#usage) will cover applying the output in OBS.
+This section is for interracting with the program once setup.
 
-### Adding DJs
+## GUI Setup
 
-DJs can be added either on the main page, or inside of an event by clicking on the **+** button for DJs. Each entry has the following properties:
+Moved to `/help` in the GUI, as the process and parameters are subject to change.
 
-| Property | Description |
-| ----- | ----- |
-| `DJ Name` | Name used to reference the entry, this cannot be changed in the future |
-| `Public Name` | Name to override `DJ Name` if updates are needed |
-| `Discord ID` | Currently not used, but planned use in future functionality |
-| `Logo File` | File pointing to the local file/url for the DJ's logo |
-| `RTMP Server` | Which RTMP server the DJ is connecting to if live |
-| `Stream Key` | DJ's unique stream key used when connecting for a live stream |
-| `Recording File` | File pointing to the local file/url for the DJ's recording |
-
-If a `Logo File` is not set, `DJ Name` as a text element will be used for OBS unless `Public Name` is set.
-
-Both the `Logo File` and `Recording File` point to a `File` object, which can be accessed/set by clicking on the button next to each respective line.
-
-`File` objects can either point to a local file set in the directories specified in the README (`LOCAL_LOGOS_PATH` and `LOCAL_RECORDINGS_PATH`), or to a URL which it will use the `FILE_SERVER_AUTHORIZATION` when accessing. When picking a local file, a preview will be displayed if the browser can render it (Firefox by default lacks a lot of compatibility).
-
-
-### Adding Promos
-
-Much like DJs, promos can be added either on the main page or in an event's popup. To display promos on the front page click the button next to the **+** with two arrows. Promos only have two properties:
-
-| Property | Description |
-| ----- | ----- |
-| `Promo Name` | Name used to reference the entry, this cannot be changed in the future |
-| `Recording File` | File pointing to the local file/url for the Promo's recording |
-
-This is the same `File` object as for DJs.
-In OBS, promos will be added as a single vlc playlist of all files.
-
-### Accessing DJs and Promos
-
-Existing entries can be accessed by clicking on the row with their name on it, in the case of having too many elements to easily find the table headers (#/Name/Logo/etc) can be clicked on to sort all entries in table. Additionally entries can be searched for by entering text in the search bar, and either hitting `Enter` clicking outside of the text box.
-
-### Creating an Event
-
-Events can be created by clicking on the **+** button under Events on the right side of the screen, the only input for this is the event's name. Like DJs and Promos, the name is immutable after creation.
-
-### Accessing an Event
-
-Events can be accessed, sorted, and filtered just as DJs/Promos. By default Events will be sorted by most recently created. Events have the following 
-
-Events have the following values/windows:
-
-- DJs
-- Promos
-- Day & Time
-- Checklist
-- Theme
-- Export
-- Event Info
-
-### Event DJs
-
-Each event will have a list of DJs, they can be added by clicking the **+** button next the `DJs`. In this window you can either select an existing DJ to add, or create a new entry. After adding DJs, their order can be changed by dragging and dropping their table row. Each Event DJ has the following properties:
-
-| Property | Description |
-| ----- | ----- |
-| `Is Live` | If the DJ will be live streaming |
-| `VJ Name` | If the DJ's visuals should be credited with a VJ |
-
-By clicking on an Event DJ these values can be updated, along with a quick summary on the rest of the DJ's entry. The DJ can be edited as well by clicking on the pencil icon in the top right.
-
-### Event Promos
-
-Similar to `Event DJs`, but will have no proprties unique to the event.
-
-### Event Day & Time
-
-Accessed by clicking the Calendar icon in the top right, the day and time (eastern) can be set here.
-
-### Event Checklist
-
-Using the data from `Day & Time`, the checklist highlights what preperations should have been/to take based on the number of days left till the event.
-
-### Event Theme
-
-Defines files and dimensions for a Theme, once a Theme is created it can be used by any Event. Themes have the following properties:
-
-| Property | Description |
-| ----- | ----- |
-| `Overlay` | `File` used for the stream overlay |
-| `Starting File` | `File` used as "stream starting soon" or similar media |
-| `Ending File` | `File` used as "stream has ended" or similar media |
-| `Video Dimensions` | The height and width the overlay is designed to accomodate |
-| `Video Offset` | The X and Y offsets (from the top left) to fit files inside the overlay |
-| `Chat Dimensions` | Same as `Video Dimensions` for stream chat |
-| `Chat Offset` | Same as `Video Offset` for stream chat |
-
-`Overlay`, `Starting File`, and `Ending File` will have access to local files in `LOCAL_THEMES_PATH`.
-
-### Event Info
-
-A brief summary of the above values at a glance.
-
-### Event Export
-
-Exports a `json` file with the same name as the Event for use with the OBS script, files are written to `LOCAL_EXPORT_PATH`
-
-*Note: Currently does not give any feedback on success/failure*
-
-## Usage
+## OBS Usage
 
 After exporting an event, how to add it to OBS including setting up scene automation.
 
@@ -122,9 +22,13 @@ If the event's theme has a starting/ending file, their scenes must be removed.
 
 If using automation, open `Tools>Automatic Scene Switcher` and under the `Macros` tab remove all existing macros.
 
+### Automating Cleanup
+
+Searching online, you can find where OBS stores the current scene data (windows is in %APPDATA%, etc). Cleaning up OBS and keeping a copy of the scene `.json`, you can overwrite the scene data when preparing to import a new event instead of manually deleting scenes and automation sequences.
+
 ### Importing an Event
 
-Open `Tools>Scripts` and select `shizu_obs_hijack_script.py`, if this doesn't exist then make sure to add it as well have python setup for OBS. Specifics for this script can be found in [this README](/OBS%20Script/README.md), but generally the usage is:
+Open `Tools>Scripts` and select `shizu_obs_hijack_script.py`, if this doesn't exist then make sure to add it (as well have python setup for OBS). Specifics for this script can be found in [this README](/OBS%20Script/README.md), but generally the usage is:
 - Select the Event's `json` file
 - Select `Translate to Host Paths`
 - Select `Generate OBS Macros` if using automation
@@ -133,9 +37,9 @@ After clicking `Update Event`, the new scenes/items will be generated.
 
 ### Importing Automation
 
-After importing the event, an automation `txt` will have been created in the same folder as the Event's `json` file was located. open `Tools>Automatic Scene Switcher` and under the `General` tab click `Import` (you will probably have to scroll down for this) and select the `txt` file with the Event's name.
+After importing the event, an automation `.txt` will have been created in the same folder as the Event's `.json` file was located. open `Tools>Automatic Scene Switcher` and under the `General` tab click `Import` (you will probably have to scroll down for this) and select the `.txt` file with the Event's name.
 
-The automation logic works only as DJs -> Last DJ -> Promos (if added) -> Ending Scene. If any edits need to be made, they can be done from the Automatic Scene Switcher.
+The automation logic works only as DJs -> Promos (if added) -> Ending Scene. If any edits need to be made, they can be done from the Automatic Scene Switcher. Automations will only be created for DJs that are pre-recorded, as live DJs won't have any triggers to work with at this time.
 
 ### Adjusting Event Elements
 

--- a/backend/openapi/schema.yaml
+++ b/backend/openapi/schema.yaml
@@ -244,6 +244,25 @@ components:
         recording:
           description: Recording file identifier for pre-recorded DJs.
           type: string
+    EventDJ:
+      type: object
+      properties:
+        event:
+          description: Event the DJ played in
+          type: string
+        is_live:
+          description: If the DJ was using a RTMP config for streaming.
+          type: boolean
+        vj:
+          description: Present if the visuals for a DJ were done by a VJ.
+          type: string
+        date:
+          description: Date of the event.
+          type: string
+    EventDJs:
+      type: array
+      items:
+        $ref: '#/components/schemas/EventDJ'
     UpdateLineupDJ:
       type: object
       properties:
@@ -1043,6 +1062,25 @@ paths:
           description: Deleted DJ.
         '404':
           description: DJ not found.
+  /dj/{djName}/events:
+    get:
+      tags:
+        - djs
+      summary: Returns a list of events a DJ is in.
+      parameters:
+        - name: djName
+          in: path
+          required: true
+          schema:
+            type: string
+            minimum: 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventDJs'
   /event:
     get:
       tags:

--- a/backend/openapi/schema.yaml
+++ b/backend/openapi/schema.yaml
@@ -169,9 +169,6 @@ components:
         logo:
           description: Logo file identifier.
           type: string
-        recording:
-          description: Recording file identifier.
-          type: string
         rtmp_server:
           description: Specific RTMP server to use for live streams.
           type: string
@@ -194,9 +191,6 @@ components:
       properties:
         logo:
           description: Logo file identifier.
-          type: string
-        recording:
-          description: Recording file identifier.
           type: string
         rtmp_server:
           description: Specific RTMP server to use for live streams.
@@ -228,9 +222,6 @@ components:
         logo:
           description: Logo file identifier.
           type: string
-        recording:
-          description: Recording file identifier.
-          type: string
         rtmp_server:
           description: Specific RTMP server to use for live streams.
           type: string
@@ -249,6 +240,9 @@ components:
           type: boolean
         vj:
           description: Present if the visuals for a DJ are done by a VJ.
+          type: string
+        recording:
+          description: Recording file identifier for pre-recorded DJs.
           type: string
     UpdateLineupDJ:
       type: object

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -1065,7 +1065,7 @@ export const import_legacy_ledger = async (ledger_path: string) => {
 export const import_legacy_events = async (lineups_path: string) => {
   const errors = [];
   const new_events: IEventObject[] = [];
-  const all_events_djs: Map<String, IEventDjObject[]> = new Map();
+  const all_events_djs: Map<string, IEventDjObject[]> = new Map();
 
   // Expect a folder containing multiple lineups
   const lineup_files = readdirSync(lineups_path, { withFileTypes: true });

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -302,10 +302,10 @@ export const create_tables = async () => {
   try {
     await run_migrations(client);
     // Initial theme values for GUI
-    // const themes = await client.query(
-    //   `SELECT * FROM ${APP_THEMES_TABLE.name};`,
-    // );
-    // if (themes.rows.length === 0) await initial_data();
+    const themes = await client.query(
+      `SELECT * FROM ${APP_THEMES_TABLE.name};`,
+    );
+    if (themes.rows.length === 0) await initial_data();
   } finally {
     await client.end();
   }

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -51,6 +51,7 @@ import {
   internal_set_event_date_time,
   internal_set_event_theme,
   internal_update_event,
+  internal_get_events_ordered,
 } from "./database_helpers/event_db_helpers";
 import {
   internal_delete_promo,
@@ -153,10 +154,8 @@ export const read_themes_table = async () => {
 
 export const read_events_table = async () => {
   const pool = await database_pool.connect();
-  const retval: QueryResult<IEventObject> = await internal_read_entire_table(
-    EVENTS_TABLE,
-    pool,
-  );
+  const retval: QueryResult<IEventObject> =
+    await internal_get_events_ordered(pool);
   await pool.release();
   return retval.rows;
 };
@@ -172,6 +171,9 @@ export const read_promos_table = async () => {
 };
 
 export const get_promos_by_names = async (names: string[], event?: string) => {
+  if (names === null || names === undefined || names.length === 0) {
+    return [];
+  }
   const pool = await database_pool.connect();
   const retval: QueryResult<IPromoObject> = await internal_get_promos(
     names,
@@ -300,10 +302,10 @@ export const create_tables = async () => {
   try {
     await run_migrations(client);
     // Initial theme values for GUI
-    const themes = await client.query(
-      `SELECT * FROM ${APP_THEMES_TABLE.name};`,
-    );
-    if (themes.rows.length === 0) await initial_data();
+    // const themes = await client.query(
+    //   `SELECT * FROM ${APP_THEMES_TABLE.name};`,
+    // );
+    // if (themes.rows.length === 0) await initial_data();
   } finally {
     await client.end();
   }

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -246,13 +246,18 @@ export const get_app_theme = async (name: string) => {
 
 export const create_tables = async () => {
   const client = database_client();
-  await run_migrations(client);
+  client.connect();
 
-  // Initial theme values for GUI
-  const themes = await client.query(`SELECT * FROM ${APP_THEMES_TABLE.name};`);
-  if (themes.rows.length === 0) await initial_data();
-
-  await client.end();
+  try {
+    await run_migrations(client);
+    // Initial theme values for GUI
+    const themes = await client.query(
+      `SELECT * FROM ${APP_THEMES_TABLE.name};`,
+    );
+    if (themes.rows.length === 0) await initial_data();
+  } finally {
+    await client.end();
+  }
 };
 
 const initial_data = async () => {

--- a/backend/src/database_helpers/app_themes_db_helpers.ts
+++ b/backend/src/database_helpers/app_themes_db_helpers.ts
@@ -64,7 +64,7 @@ export const internal_update_app_themes = async (
   const validation = await validate_app_theme(name, true, pool);
   if (validation !== undefined) return validation;
 
-  await internal_update_table_entry(APP_THEMES_TABLE, { name, style }, pool);
+  await internal_update_table_entry(APP_THEMES_TABLE, name, { style }, pool);
 };
 
 export const internal_delete_app_themes = async (

--- a/backend/src/database_helpers/app_themes_db_helpers.ts
+++ b/backend/src/database_helpers/app_themes_db_helpers.ts
@@ -64,7 +64,12 @@ export const internal_update_app_themes = async (
   const validation = await validate_app_theme(name, true, pool);
   if (validation !== undefined) return validation;
 
-  await internal_update_table_entry(APP_THEMES_TABLE, name, { style }, pool);
+  await internal_update_table_entry(
+    APP_THEMES_TABLE,
+    name,
+    { style: style },
+    pool,
+  );
 };
 
 export const internal_delete_app_themes = async (

--- a/backend/src/database_helpers/app_themes_db_helpers.ts
+++ b/backend/src/database_helpers/app_themes_db_helpers.ts
@@ -64,12 +64,7 @@ export const internal_update_app_themes = async (
   const validation = await validate_app_theme(name, true, pool);
   if (validation !== undefined) return validation;
 
-  await internal_update_table_entry(
-    APP_THEMES_TABLE,
-    name,
-    { style: style },
-    pool,
-  );
+  await internal_update_table_entry(APP_THEMES_TABLE, name, { style }, pool);
 };
 
 export const internal_delete_app_themes = async (

--- a/backend/src/database_helpers/dj_db_helpers.ts
+++ b/backend/src/database_helpers/dj_db_helpers.ts
@@ -8,6 +8,7 @@ import { DJS_TABLE, FILES_TABLE, EVENT_DJS_TABLE } from "../tables";
 import { IDjObject, IEventDjObject } from "../types";
 import { PoolClient, QueryResult } from "pg";
 import { internal_delete_event_dj } from "./event_dj_db_helpers";
+import { internal_delete_file } from "./file_db_helpers";
 
 const validate_dj = async (
   dj_data: IDjObject,
@@ -100,9 +101,10 @@ export const internal_delete_dj = async (dj_name: string, pool: PoolClient) => {
     await pool.query(event_djs_query);
 
   if (event_djs.rows && event_djs.rows.length > 0) {
-    // TODO: Shift later djs to lower position
     for (const event_dj of event_djs.rows) {
       await internal_delete_event_dj(event_dj.event, dj_name, pool);
+      if (event_dj.recording)
+        await internal_delete_file(event_dj.recording, pool);
     }
   }
 

--- a/backend/src/database_helpers/dj_db_helpers.ts
+++ b/backend/src/database_helpers/dj_db_helpers.ts
@@ -1,17 +1,11 @@
 import {
   internal_insert_into_table,
   internal_update_table_entry,
-  internal_get_row_from_table,
   is_non_empty,
 } from "./helper_functions";
 import { djNotFoundError, invalidDjError, invalidFileError } from "../errors";
-import {
-  DJS_TABLE,
-  FILES_TABLE,
-  EVENTS_TABLE,
-  EVENT_DJS_TABLE,
-} from "../tables";
-import { IDjObject, IEventDjObject, IEventObject } from "../types";
+import { DJS_TABLE, FILES_TABLE, EVENT_DJS_TABLE } from "../tables";
+import { IDjObject, IEventDjObject } from "../types";
 import { PoolClient, QueryResult } from "pg";
 import { internal_delete_event_dj } from "./event_dj_db_helpers";
 

--- a/backend/src/database_helpers/event_db_helpers.ts
+++ b/backend/src/database_helpers/event_db_helpers.ts
@@ -6,22 +6,19 @@ import {
   is_non_empty,
 } from "./helper_functions";
 import {
-  invalidDjError,
   invalidEventError,
   invalidPromoError,
-  djNotFoundError,
   promoNotFoundError,
   themeNotFoundError,
   invalidActionError,
 } from "../errors";
 import {
   EVENTS_TABLE,
-  DJS_TABLE,
   PROMOS_TABLE,
   THEMES_TABLE,
   EVENT_DJS_TABLE,
 } from "../tables";
-import { IDjObject, IEventObject, ILineupDjObject } from "../types";
+import { IEventObject } from "../types";
 
 const validate_event = async (
   event_data: IEventObject,

--- a/backend/src/database_helpers/event_db_helpers.ts
+++ b/backend/src/database_helpers/event_db_helpers.ts
@@ -14,7 +14,13 @@ import {
   themeNotFoundError,
   invalidActionError,
 } from "../errors";
-import { EVENTS_TABLE, DJS_TABLE, PROMOS_TABLE, THEMES_TABLE } from "../tables";
+import {
+  EVENTS_TABLE,
+  DJS_TABLE,
+  PROMOS_TABLE,
+  THEMES_TABLE,
+  EVENT_DJS_TABLE,
+} from "../tables";
 import { IDjObject, IEventObject, ILineupDjObject } from "../types";
 
 const validate_event = async (
@@ -234,6 +240,11 @@ export const internal_delete_event = async (
     pool,
   )) as IEventObject | Error;
   if (event instanceof Error) return event;
+
+  const event_dj_query = `DELETE FROM ${EVENT_DJS_TABLE.name} WHERE event = '${event_name}'`;
+  console.log(event_dj_query);
+
+  await pool.query(event_dj_query);
 
   const query = `DELETE FROM ${EVENTS_TABLE.name} WHERE name = '${event_name}'`;
   console.log(query);

--- a/backend/src/database_helpers/event_db_helpers.ts
+++ b/backend/src/database_helpers/event_db_helpers.ts
@@ -63,6 +63,12 @@ const validate_event = async (
   }
 };
 
+export const internal_get_events_ordered = (pool: PoolClient) => {
+  const query = `SELECT * FROM ${EVENTS_TABLE.name} ORDER BY date DESC NULLS LAST, start_time DESC, name ASC;`;
+  console.log(query);
+  return pool.query(query);
+};
+
 export const internal_insert_into_events = async (
   event_data: IEventObject,
   pool: PoolClient,

--- a/backend/src/database_helpers/event_db_helpers.ts
+++ b/backend/src/database_helpers/event_db_helpers.ts
@@ -15,7 +15,7 @@ import {
   invalidActionError,
 } from "../errors";
 import { EVENTS_TABLE, DJS_TABLE, PROMOS_TABLE, THEMES_TABLE } from "../tables";
-import { IEventObject, ILineupDjObject } from "../types";
+import { IDjObject, IEventObject, ILineupDjObject } from "../types";
 
 const validate_event = async (
   event_data: IEventObject,
@@ -32,23 +32,6 @@ const validate_event = async (
   } else {
     if (exists.rows && exists.rows.length > 0) {
       return invalidEventError(`Event ${event_data.name} already exists!`);
-    }
-  }
-  if (event_data.djs !== undefined && event_data.djs.length > 0) {
-    const djs_condition = event_data.djs
-      .map((dj) => `name = '${dj.name}'`)
-      .join(" OR ");
-    exists = await pool.query(
-      `SELECT * FROM ${DJS_TABLE.name} WHERE ${djs_condition};`,
-    );
-    if (!exists.rows || exists.rows.length !== event_data.djs.length) {
-      const db_djs = exists.rows.map((row: ILineupDjObject) => row.name);
-      const missing_set = event_data.djs.filter(
-        (dj) => !db_djs.includes(dj.name),
-      );
-      return djNotFoundError(
-        `The following DJs do not exist (${missing_set}), add DJs to the DB before attempting to reference them.`,
-      );
     }
   }
   if (event_data.promos !== undefined && event_data.promos.length > 0) {
@@ -92,40 +75,7 @@ export const internal_insert_into_events = async (
   await internal_insert_into_table(EVENTS_TABLE, event_data, pool);
 };
 
-export const internal_add_event_dj = async (
-  event_name: string,
-  dj_data: ILineupDjObject,
-  pool: PoolClient,
-) => {
-  const dj = await internal_get_row_from_table(DJS_TABLE, dj_data.name, pool);
-  if (dj instanceof Error) return dj;
-  const event = (await internal_get_row_from_table(
-    EVENTS_TABLE,
-    event_name,
-    pool,
-  )) as IEventObject | Error;
-  if (event instanceof Error) return event;
-  let event_djs = event.djs;
-  if (!event_djs || event_djs.length === 0) {
-    event_djs = [dj_data];
-  } else {
-    const event_dj_index = event_djs.findIndex(
-      (event_dj: ILineupDjObject) => event_dj.name === dj_data.name,
-    );
-    if (event_dj_index !== -1) {
-      return invalidDjError(
-        `DJ ${dj_data.name} already exists in Event ${event_name}.`,
-      );
-    }
-    event_djs.push(dj_data);
-  }
-
-  const update_query = `UPDATE ${EVENTS_TABLE.name} SET djs = '${JSON.stringify(event_djs)}' WHERE name = '${event_name}';`;
-  console.log(update_query);
-  await pool.query(update_query);
-};
-
-export const internal_add_event_promo = async (
+export const internal_event_add_promo = async (
   event_name: string,
   promo_name: string,
   pool: PoolClient,
@@ -175,74 +125,12 @@ export const internal_update_event = async (
   if (validation !== undefined) return validation;
 
   // Add to DB
-  await internal_update_table_entry(EVENTS_TABLE, event_data, pool);
-};
-
-export const internal_update_event_dj = async (
-  event_name: string,
-  dj_name: string,
-  pool: PoolClient,
-  is_live?: boolean,
-  vj?: string,
-) => {
-  const event = (await internal_get_row_from_table(
+  await internal_update_table_entry(
     EVENTS_TABLE,
-    event_name,
+    event_data.name,
+    event_data,
     pool,
-  )) as IEventObject | Error;
-  if (event instanceof Error) return event;
-  const event_djs = event.djs;
-  if (!event_djs || event_djs.length === 0) {
-    return invalidDjError(
-      `DJ ${dj_name} does not exist in Event ${event_name}.`,
-    );
-  }
-  const event_dj_index = event_djs.findIndex(
-    (dj: ILineupDjObject) => dj.name === dj_name,
   );
-  if (event_dj_index === -1) {
-    return invalidPromoError(
-      `DJ ${dj_name} does not exist in Event ${event_name}.`,
-    );
-  }
-
-  if (is_live !== undefined) event_djs[event_dj_index].is_live = is_live;
-  if (vj !== undefined) event_djs[event_dj_index].vj = vj;
-
-  const update_query = `UPDATE ${EVENTS_TABLE.name} SET djs = '${JSON.stringify(event_djs)}' WHERE name = '${event_name}';`;
-  console.log(update_query);
-  await pool.query(update_query);
-};
-
-export const internal_remove_event_dj = async (
-  event_name: string,
-  dj_name: string,
-  pool: PoolClient,
-) => {
-  const event = (await internal_get_row_from_table(
-    EVENTS_TABLE,
-    event_name,
-    pool,
-  )) as IEventObject | Error;
-  if (event instanceof Error) return event;
-  const event_djs = event.djs;
-  if (!event_djs || event_djs.length === 0) {
-    return invalidDjError(
-      `DJ ${dj_name} does not exist in Event ${event_name}.`,
-    );
-  }
-  const event_dj_index = event_djs.findIndex(
-    (dj: ILineupDjObject) => dj.name === dj_name,
-  );
-  if (event_dj_index === -1) {
-    return invalidDjError(
-      `DJ ${dj_name} does not exist in Event ${event_name}.`,
-    );
-  }
-
-  const update_query = `UPDATE ${EVENTS_TABLE.name} SET djs = '${JSON.stringify(event_djs.filter((dj) => dj.name !== dj_name))}' WHERE name = '${event_name}';`;
-  console.log(update_query);
-  await pool.query(update_query);
 };
 
 export const internal_remove_event_promo = async (
@@ -280,46 +168,6 @@ export const internal_remove_event_promo = async (
     update_query = `UPDATE ${EVENTS_TABLE.name} SET promos = ARRAY[${new_promo_array}] WHERE name = '${event_name}';`;
   }
   console.log(update_query);
-  await pool.query(update_query);
-};
-
-export const internal_move_event_dj = async (
-  event_name: string,
-  index_a: number,
-  index_b: number,
-  pool: PoolClient,
-) => {
-  const event = await internal_get_row_from_table(
-    EVENTS_TABLE,
-    event_name,
-    pool,
-  );
-  if (event instanceof Error) return event;
-  if (
-    index_a < 0 ||
-    index_a >= event.djs.length ||
-    index_b < 0 ||
-    index_b >= event.djs.length
-  ) {
-    return invalidActionError(
-      `The move indexes (${index_a}, ${index_b}) are not valid for Event ${event_name}.`,
-    );
-  }
-
-  if (index_a === index_b) return "Done";
-
-  const moving_value = event.djs[index_a];
-  const target_value = event.djs[index_b];
-  event.djs.splice(index_a, 1);
-  if (index_a > index_b) {
-    event.djs.splice(event.djs.indexOf(target_value), 0, moving_value);
-  } else {
-    event.djs.splice(event.djs.indexOf(target_value) + 1, 0, moving_value);
-  }
-
-  const update_query = `UPDATE ${EVENTS_TABLE.name} SET djs = '${JSON.stringify(event.djs)}' WHERE name = '${event_name}';`;
-  console.log(update_query);
-
   await pool.query(update_query);
 };
 

--- a/backend/src/database_helpers/event_dj_db_helpers.ts
+++ b/backend/src/database_helpers/event_dj_db_helpers.ts
@@ -1,0 +1,235 @@
+import {
+  internal_insert_into_table,
+  internal_update_table_entry,
+  internal_get_row_from_table,
+  is_non_empty,
+} from "./helper_functions";
+import {
+  djNotFoundError,
+  invalidActionError,
+  invalidDjError,
+  invalidEventError,
+  invalidFileError,
+} from "../errors";
+import {
+  DJS_TABLE,
+  FILES_TABLE,
+  EVENTS_TABLE,
+  EVENT_DJS_TABLE,
+} from "../tables";
+import { IDjObject, IEventDjObject, IEventObject } from "../types";
+import { PoolClient, QueryResult } from "pg";
+
+const validate_event_dj = async (
+  event_dj_object: IEventDjObject,
+  update: boolean,
+  pool: PoolClient,
+) => {
+  const exists: QueryResult<IEventDjObject> = await pool.query(
+    `SELECT * FROM ${EVENT_DJS_TABLE.name} WHERE event = '${event_dj_object.event}' and dj = '${event_dj_object.dj}';`,
+  );
+  if (update) {
+    if (!exists.rows || exists.rows.length === 0) {
+      return djNotFoundError(
+        `Event DJ ${event_dj_object.event}:${event_dj_object.dj} does not exist.`,
+      );
+    }
+  } else {
+    if (exists.rows && exists.rows.length > 0) {
+      return invalidDjError(
+        `Event DJ ${event_dj_object.event}:${event_dj_object.dj} already exists!`,
+      );
+    }
+  }
+  if (is_non_empty(event_dj_object.recording)) {
+    const file_exists = await pool.query(
+      `SELECT 1 FROM ${FILES_TABLE.name} WHERE name = '${event_dj_object.recording}'`,
+    );
+    if (!file_exists.rows || file_exists.rows.length === 0) {
+      return invalidFileError(
+        `Recording file ${event_dj_object.recording} does not exist, add files to the DB before attempting to reference them.`,
+      );
+    }
+  }
+  return exists.rows[0];
+};
+
+export const internal_get_event_dj = async (
+  event_name: string,
+  dj_name: string,
+  pool: PoolClient,
+) => {
+  const composite_key = `('${event_name}', '${dj_name}')`;
+  const event_dj = (await internal_get_row_from_table(
+    EVENT_DJS_TABLE,
+    composite_key,
+    pool,
+  )) as IEventDjObject | Error;
+  if (event_dj instanceof Error) return event_dj;
+  return event_dj;
+};
+
+export const internal_get_event_djs_by_event = async (
+  event_name: string,
+  pool: PoolClient,
+) => {
+  const retval: QueryResult<IEventDjObject> = await pool.query(
+    `SELECT * FROM ${EVENT_DJS_TABLE.name} WHERE event = '${event_name}' ORDER BY position;`,
+  );
+  return retval.rows;
+};
+
+export const internal_insert_into_event_djs = async (
+  event_dj_data: IEventDjObject,
+  pool: PoolClient,
+) => {
+  const validation = await validate_event_dj(event_dj_data, false, pool);
+  if (validation instanceof Error) return validation;
+
+  // Get last position
+  const number_of_event_djs = await internal_get_event_djs_by_event(
+    event_dj_data.event,
+    pool,
+  );
+  event_dj_data.position = number_of_event_djs.length;
+
+  // Add to DB
+  await internal_insert_into_table(EVENT_DJS_TABLE, event_dj_data, pool);
+};
+
+export const internal_update_event_dj = async (
+  event_dj_data: IEventDjObject,
+  pool: PoolClient,
+) => {
+  const validation = await validate_event_dj(event_dj_data, true, pool);
+  if (validation instanceof Error) return validation;
+
+  // Keep position
+  event_dj_data.position = validation.position;
+
+  // Add to DB
+  const composite_key = `('${event_dj_data.event}', '${event_dj_data.dj}')`;
+  await internal_update_table_entry(
+    EVENT_DJS_TABLE,
+    composite_key,
+    event_dj_data,
+    pool,
+  );
+};
+
+export const internal_move_event_dj = async (
+  event_name: string,
+  index_a: number,
+  index_b: number,
+  pool: PoolClient,
+) => {
+  const event_djs = await internal_get_event_djs_by_event(event_name, pool);
+  if (event_djs.length === 0)
+    return invalidEventError(`No DJs found for event ${event_name}`);
+  if (
+    index_a < 0 ||
+    index_a >= event_djs.length ||
+    index_b < 0 ||
+    index_b >= event_djs.length
+  ) {
+    return invalidActionError(
+      `The move indexes (${index_a}, ${index_b}) are not valid for Event ${event_name}.`,
+    );
+  }
+  if (index_a === index_b) return "Done";
+
+  const moving_event_dj = event_djs[index_a];
+
+  if (index_a > index_b) {
+    const shift_down = event_djs.slice(index_b, index_a);
+    for (const shift_dj of shift_down) {
+      shift_dj.position += 1;
+      await internal_update_event_dj(shift_dj, pool);
+    }
+  } else {
+    const shift_up = event_djs.slice(index_a + 1, index_b + 1);
+    for (const shift_dj of shift_up) {
+      shift_dj.position -= 1;
+      await internal_update_event_dj(shift_dj, pool);
+    }
+  }
+
+  moving_event_dj.position = index_b;
+  await internal_update_event_dj(moving_event_dj, pool);
+};
+
+export const internal_static_change_event_djs = async (
+  event_name: string,
+  new_event_djs: IEventDjObject[],
+  pool: PoolClient,
+) => {
+  const current_event_djs = await internal_get_event_djs_by_event(
+    event_name,
+    pool,
+  );
+  const new_event_dj_names = new_event_djs.map((dj) => dj.dj);
+  const deleted_djs = current_event_djs.filter(
+    (event_dj) => !new_event_dj_names.includes(event_dj.dj),
+  );
+  const old_dj_names = current_event_djs.map((dj) => dj.dj);
+  const new_djs = new_event_djs.filter(
+    (event_dj) => !old_dj_names.includes(event_dj.dj),
+  );
+
+  // Delete old entries
+  for (const delete_dj of deleted_djs) {
+    const composite_key = `('${delete_dj.event}', '${delete_dj.dj}')`;
+    await pool.query(EVENT_DJS_TABLE.delete_entry(composite_key));
+  }
+
+  // Create/Update as needed with new positions
+  for (let i = 0; i < new_event_djs.length; i++) {
+    const event_dj = new_event_djs[i];
+    const composite_key = `('${event_dj.event}', '${event_dj.dj}')`;
+    event_dj.position = i;
+    if (new_djs.includes(event_dj)) {
+      await internal_update_table_entry(
+        EVENT_DJS_TABLE,
+        composite_key,
+        event_dj,
+        pool,
+      );
+    } else {
+      await internal_update_table_entry(
+        EVENT_DJS_TABLE,
+        composite_key,
+        event_dj,
+        pool,
+      );
+    }
+  }
+};
+
+// Expect this to be called after an event.events_djs/event/dj deletion call
+export const internal_delete_event_dj = async (
+  event_name: string,
+  dj_name: string,
+  pool: PoolClient,
+) => {
+  // Validate entry exists
+  const composite_key = `('${event_name}', '${dj_name}')`;
+  const event_dj = (await internal_get_row_from_table(
+    EVENT_DJS_TABLE,
+    composite_key,
+    pool,
+  )) as IEventDjObject | Error;
+  if (event_dj instanceof Error) return event_dj;
+
+  // Shift other entries
+  const event_djs = await internal_get_event_djs_by_event(event_name, pool);
+  for (const shifting_dj of event_djs.slice(event_dj.position)) {
+    shifting_dj.position -= 1;
+    await internal_update_event_dj(shifting_dj, pool);
+  }
+
+  // TODO: delete recording
+
+  // Delete entry
+  console.log(EVENT_DJS_TABLE.delete_entry(composite_key));
+  await pool.query(EVENT_DJS_TABLE.delete_entry(composite_key));
+};

--- a/backend/src/database_helpers/event_dj_db_helpers.ts
+++ b/backend/src/database_helpers/event_dj_db_helpers.ts
@@ -172,9 +172,9 @@ export const internal_static_change_event_djs = async (
     (event_dj) => !new_event_dj_names.includes(event_dj.dj),
   );
   const old_dj_names = current_event_djs.map((dj) => dj.dj);
-  const new_djs = new_event_djs.filter(
-    (event_dj) => !old_dj_names.includes(event_dj.dj),
-  );
+  const new_djs = new_event_djs
+    .map((dj) => dj.dj)
+    .filter((event_dj) => !old_dj_names.includes(event_dj));
 
   // Delete old entries
   for (const delete_dj of deleted_djs) {
@@ -187,13 +187,8 @@ export const internal_static_change_event_djs = async (
     const event_dj = new_event_djs[i];
     const composite_key = `('${event_dj.event}', '${event_dj.dj}')`;
     event_dj.position = i;
-    if (new_djs.includes(event_dj)) {
-      await internal_update_table_entry(
-        EVENT_DJS_TABLE,
-        composite_key,
-        event_dj,
-        pool,
-      );
+    if (new_djs.includes(event_dj.dj)) {
+      await internal_insert_into_event_djs(event_dj, pool);
     } else {
       await internal_update_table_entry(
         EVENT_DJS_TABLE,

--- a/backend/src/database_helpers/event_dj_db_helpers.ts
+++ b/backend/src/database_helpers/event_dj_db_helpers.ts
@@ -227,8 +227,6 @@ export const internal_delete_event_dj = async (
     await internal_update_event_dj(shifting_dj, pool);
   }
 
-  // TODO: delete recording
-
   // Delete entry
   console.log(EVENT_DJS_TABLE.delete_entry(composite_key));
   await pool.query(EVENT_DJS_TABLE.delete_entry(composite_key));

--- a/backend/src/database_helpers/event_dj_db_helpers.ts
+++ b/backend/src/database_helpers/event_dj_db_helpers.ts
@@ -11,13 +11,8 @@ import {
   invalidEventError,
   invalidFileError,
 } from "../errors";
-import {
-  DJS_TABLE,
-  FILES_TABLE,
-  EVENTS_TABLE,
-  EVENT_DJS_TABLE,
-} from "../tables";
-import { IDjObject, IEventDjObject, IEventObject } from "../types";
+import { FILES_TABLE, EVENT_DJS_TABLE, EVENTS_TABLE } from "../tables";
+import { IEventDjObject } from "../types";
 import { PoolClient, QueryResult } from "pg";
 
 const validate_event_dj = async (
@@ -75,6 +70,16 @@ export const internal_get_event_djs_by_event = async (
 ) => {
   const retval: QueryResult<IEventDjObject> = await pool.query(
     `SELECT * FROM ${EVENT_DJS_TABLE.name} WHERE event = '${event_name}' ORDER BY position;`,
+  );
+  return retval.rows;
+};
+
+export const internal_get_event_djs_by_dj = async (
+  dj_name: string,
+  pool: PoolClient,
+) => {
+  const retval: QueryResult<any> = await pool.query(
+    `SELECT event, is_live, vj, date FROM ${EVENT_DJS_TABLE.name} INNER JOIN ${EVENTS_TABLE.name} ON name = event WHERE dj = '${dj_name}' ORDER BY date asc, event asc;`,
   );
   return retval.rows;
 };

--- a/backend/src/database_helpers/file_db_helpers.ts
+++ b/backend/src/database_helpers/file_db_helpers.ts
@@ -1,6 +1,12 @@
 import { PoolClient } from "pg";
 import { fileNotFoundError, invalidFileError } from "../errors";
-import { DJS_TABLE, FILES_TABLE, PROMOS_TABLE, THEMES_TABLE } from "../tables";
+import {
+  DJS_TABLE,
+  EVENT_DJS_TABLE,
+  FILES_TABLE,
+  PROMOS_TABLE,
+  THEMES_TABLE,
+} from "../tables";
 import { IEventObject, IFileObject } from "../types";
 import {
   internal_get_row_from_table,
@@ -89,7 +95,7 @@ export const internal_delete_file = async (
     `UPDATE ${DJS_TABLE.name} SET logo = DEFAULT WHERE logo = '${file_name}';`,
   );
   await pool.query(
-    `UPDATE ${DJS_TABLE.name} SET recording = DEFAULT WHERE recording = '${file_name}';`,
+    `UPDATE ${EVENT_DJS_TABLE.name} SET recording = DEFAULT WHERE recording = '${file_name}';`,
   );
 
   const delete_query = `DELETE FROM ${FILES_TABLE.name} WHERE name = '${file_name}'`;

--- a/backend/src/database_helpers/file_db_helpers.ts
+++ b/backend/src/database_helpers/file_db_helpers.ts
@@ -48,7 +48,12 @@ export const internal_update_file = async (
   if (validation !== undefined) return validation;
 
   // Add to DB
-  await internal_update_table_entry(FILES_TABLE, file_data, pool);
+  await internal_update_table_entry(
+    FILES_TABLE,
+    file_data.name,
+    file_data,
+    pool,
+  );
 };
 
 export const internal_delete_file = async (

--- a/backend/src/database_helpers/helper_functions.ts
+++ b/backend/src/database_helpers/helper_functions.ts
@@ -100,6 +100,14 @@ export const internal_insert_into_table = async (
   const columns = [];
   const values = [];
   for (const definition of table.definitions) {
+    if (
+      obj_data[definition.name] === null ||
+      obj_data[definition.name] === undefined ||
+      (obj_data[definition.name] instanceof Array &&
+        obj_data[definition.name].length === 0)
+    ) {
+      continue;
+    }
     switch (definition.type) {
       case "TEXT":
       case "TEXT PRIMARY KEY":

--- a/backend/src/database_helpers/helper_functions.ts
+++ b/backend/src/database_helpers/helper_functions.ts
@@ -135,11 +135,7 @@ export const internal_insert_into_table = async (
         break;
     }
   }
-  const insert_query = `
-    INSERT INTO ${table.name}
-      (${columns.join(", ")})
-      VALUES (${values.join(", ")});
-  `;
+  const insert_query = `INSERT INTO ${table.name} (${columns.join(", ")}) VALUES (${values.join(", ")});`;
 
   console.log(insert_query);
   await pool.query(insert_query);

--- a/backend/src/database_helpers/promo_db_helpers.ts
+++ b/backend/src/database_helpers/promo_db_helpers.ts
@@ -6,7 +6,6 @@ import {
 } from "./helper_functions";
 import {
   promoNotFoundError,
-  invalidFileError,
   invalidPromoError,
   fileNotFoundError,
 } from "../errors";

--- a/backend/src/database_helpers/promo_db_helpers.ts
+++ b/backend/src/database_helpers/promo_db_helpers.ts
@@ -44,6 +44,19 @@ const validate_promo = async (
   }
 };
 
+export const internal_get_promos = async (
+  promo_names: string[],
+  pool: PoolClient,
+) => {
+  const formatted_names = promo_names.map((name) => `'${name}'`).join(", ");
+  const query = `
+    SELECT * FROM ${PROMOS_TABLE.name}
+      where ${PROMOS_TABLE.primary_key} in (${formatted_names});`;
+
+  console.log(query);
+  return pool.query(query);
+};
+
 export const internal_insert_into_promos = async (
   promo_data: IPromoObject,
   pool: PoolClient,
@@ -65,7 +78,12 @@ export const internal_update_promo = async (
   if (validation !== undefined) return validation;
 
   // Add to DB
-  await internal_update_table_entry(PROMOS_TABLE, promo_data, pool);
+  await internal_update_table_entry(
+    PROMOS_TABLE,
+    promo_data.name,
+    promo_data,
+    pool,
+  );
 };
 
 export const internal_delete_promo = async (

--- a/backend/src/database_helpers/theme_db_helpers.ts
+++ b/backend/src/database_helpers/theme_db_helpers.ts
@@ -4,11 +4,7 @@ import {
   internal_get_row_from_table,
   is_non_empty,
 } from "./helper_functions";
-import {
-  fileNotFoundError,
-  invalidFileError,
-  invalidThemeError,
-} from "../errors";
+import { fileNotFoundError, invalidThemeError } from "../errors";
 import { EVENTS_TABLE, FILES_TABLE, THEMES_TABLE } from "../tables";
 import { IEventObject, IThemeObject } from "../types";
 import { PoolClient } from "pg";

--- a/backend/src/database_helpers/theme_db_helpers.ts
+++ b/backend/src/database_helpers/theme_db_helpers.ts
@@ -93,7 +93,12 @@ export const internal_update_theme = async (
   if (validation !== undefined) return validation;
 
   // Add to DB
-  await internal_update_table_entry(THEMES_TABLE, theme_data, pool);
+  await internal_update_table_entry(
+    THEMES_TABLE,
+    theme_data.name,
+    theme_data,
+    pool,
+  );
 };
 
 export const internal_delete_theme = async (

--- a/backend/src/db_migrations/initial_tables.ts
+++ b/backend/src/db_migrations/initial_tables.ts
@@ -6,7 +6,7 @@ import {
   THEMES_TABLE_NAME,
   FILES_TABLE_NAME,
   APP_THEMES_TABLE_NAME,
-  EVENT_DJ_TABLE_NAME,
+  EVENT_DJS_TABLE_NAME,
 } from "../tables";
 
 // Initial table definitions before any migrations
@@ -185,7 +185,7 @@ export const ALL_TABLES = [
 ];
 
 // Initial definition of new tables for their first migration integration
-export const EVENT_DJ_TABLE_0: Table = new Table(EVENT_DJ_TABLE_NAME, [
+export const EVENT_DJS_TABLE_0: Table = new Table(EVENT_DJS_TABLE_NAME, [
   {
     name: "event",
     type: "TEXT",
@@ -200,6 +200,10 @@ export const EVENT_DJ_TABLE_0: Table = new Table(EVENT_DJ_TABLE_NAME, [
     name: "event, dj",
     type: "PRIMARY KEY",
     multi_col: true,
+  },
+  {
+    name: "position",
+    type: "SMALLINT",
   },
   {
     name: "is_live",

--- a/backend/src/db_migrations/initial_tables.ts
+++ b/backend/src/db_migrations/initial_tables.ts
@@ -6,6 +6,7 @@ import {
   THEMES_TABLE_NAME,
   FILES_TABLE_NAME,
   APP_THEMES_TABLE_NAME,
+  EVENT_DJ_TABLE_NAME,
 } from "../tables";
 
 // Initial table definitions before any migrations
@@ -182,3 +183,35 @@ export const ALL_TABLES = [
   EVENTS_TABLE_0,
   APP_THEMES_TABLE_0,
 ];
+
+// Initial definition of new tables for their first migration integration
+export const EVENT_DJ_TABLE_0: Table = new Table(EVENT_DJ_TABLE_NAME, [
+  {
+    name: "event",
+    type: "TEXT",
+    fkey: `${EVENTS_TABLE_NAME}(name)`,
+  },
+  {
+    name: "dj",
+    type: "TEXT",
+    fkey: `${DJS_TABLE_NAME}(name)`,
+  },
+  {
+    name: "event, dj",
+    type: "PRIMARY KEY",
+    multi_col: true,
+  },
+  {
+    name: "is_live",
+    type: "BOOLEAN",
+  },
+  {
+    name: "recording",
+    type: "TEXT",
+    fkey: `${FILES_TABLE_NAME}(name)`,
+  },
+  {
+    name: "vj",
+    type: "TEXT",
+  },
+]);

--- a/backend/src/file_helpers.ts
+++ b/backend/src/file_helpers.ts
@@ -307,22 +307,23 @@ export const rebuildLegacyObjects = (ledger: ILegacyLedger) => {
         new_dj.logo = new_file.name;
       }
     }
-    if (dj.recording_path) {
-      const parsed_file = parse(dj.recording_path);
-      const file = recordings_file_map.get(parsed_file.base);
-      if (file) {
-        const trimmed_parent_path = file.parentPath.slice(
-          RECORDINGS_ROOT.length + 1,
-        );
-        const new_file: IFileObject = {
-          name: parsed_file.name,
-          root: "RECORDINGS",
-          file_path: join(trimmed_parent_path, file.name),
-        };
-        new_files.push(new_file);
-        new_dj.recording = new_file.name;
-      }
-    }
+    // TODO: Either toss this into event DJs or ignore entirely
+    // if (dj.recording_path) {
+    //   const parsed_file = parse(dj.recording_path);
+    //   const file = recordings_file_map.get(parsed_file.base);
+    //   if (file) {
+    //     const trimmed_parent_path = file.parentPath.slice(
+    //       RECORDINGS_ROOT.length + 1,
+    //     );
+    //     const new_file: IFileObject = {
+    //       name: parsed_file.name,
+    //       root: "RECORDINGS",
+    //       file_path: join(trimmed_parent_path, file.name),
+    //     };
+    //     new_files.push(new_file);
+    //     new_dj.recording = new_file.name;
+    //   }
+    // }
     new_djs.push(new_dj);
   });
   ledger.promos.forEach((promo) => {

--- a/backend/src/file_helpers.ts
+++ b/backend/src/file_helpers.ts
@@ -204,7 +204,6 @@ export const fetchFile = (url: string, local_path: string) => {
   return new Promise((promise_resolve, reject) => {
     const file_url = new URL(url);
     const options = urlToHttpOptions(file_url);
-    // TODO: move into envs/configs
     options.auth = process.env.FILE_SERVER_AUTHORIZATION;
     // TODO: switch on http/https
     const file = createWriteStream(local_path);

--- a/backend/src/openapi_routers/app_theme_router.ts
+++ b/backend/src/openapi_routers/app_theme_router.ts
@@ -3,7 +3,7 @@
 */
 
 import { Router } from "express";
-import { paths, components } from "../../openapi/schema";
+import { components } from "../../openapi/schema";
 import {
   create_new_app_theme,
   delete_app_theme,
@@ -11,7 +11,6 @@ import {
   read_app_themes_table,
   update_app_theme,
 } from "../database";
-import { internal_insert_into_app_themes } from "../database_helpers/app_themes_db_helpers";
 
 export const appThemeRouter = Router();
 

--- a/backend/src/openapi_routers/dj_router.ts
+++ b/backend/src/openapi_routers/dj_router.ts
@@ -3,10 +3,11 @@
 */
 
 import { Router } from "express";
-import { paths, components } from "../../openapi/schema";
+import { components } from "../../openapi/schema";
 import {
   delete_dj,
   get_dj,
+  get_event_djs_by_dj,
   insert_into_djs,
   read_djs_table,
   update_dj,
@@ -44,6 +45,12 @@ djRouter.get("/:djName", async (req, res) => {
   }
   res.status(200);
   return res.send(dj);
+});
+
+djRouter.get("/:djName/events", async (req, res) => {
+  const event_djs = await get_event_djs_by_dj(req.params.djName);
+  res.status(200);
+  return res.send(event_djs);
 });
 
 djRouter.get("/", async (req, res) => {

--- a/backend/src/openapi_routers/dj_router.ts
+++ b/backend/src/openapi_routers/dj_router.ts
@@ -26,7 +26,7 @@ djRouter.get("/min", async (req, res) => {
       return {
         name: dj.name,
         logo: dj.logo,
-        recording: dj.recording,
+        // recording: dj.recording,
         rtmp_server: dj.rtmp_server,
       };
     }),

--- a/backend/src/openapi_routers/event_router.ts
+++ b/backend/src/openapi_routers/event_router.ts
@@ -6,7 +6,7 @@ import { Router } from "express";
 import { paths, components } from "../../openapi/schema";
 import {
   add_event_dj,
-  add_event_promo,
+  event_add_promo,
   delete_event,
   export_event,
   get_event,
@@ -21,8 +21,9 @@ import {
   update_event_date_time,
   update_event_dj,
   event_export_summary,
+  get_event_djs_by_event,
 } from "../database";
-import { IEventObject, ILineupDjObject } from "../types";
+import { IEventObject, IEventDjObject, ILineupDjObject } from "../types";
 
 export const eventRouter = Router();
 
@@ -33,6 +34,7 @@ type lineupDJInterface = components["schemas"]["LineupDJ"];
 type updateLineupDJInterface = components["schemas"]["UpdateLineupDJ"];
 type lineupPromoInterface = components["schemas"]["LineupPromotion"];
 type moveEventItemInterface = components["schemas"]["MoveEventItem"];
+type eventExportSummaryInterface = components["schemas"]["EventExportSummary"];
 
 eventRouter.get("/min", async (req, res) => {
   const events_data = await read_events_table();
@@ -46,6 +48,24 @@ eventRouter.get("/min", async (req, res) => {
   );
 });
 
+const make_ui_event_object = async (event: IEventObject) => {
+  const event_djs = await get_event_djs_by_event(event.name);
+  const ui_event_obj: eventInterface = Object.assign({}, event);
+  if (event_djs) {
+    ui_event_obj.djs = event_djs.map((event_dj) => {
+      return {
+        name: event_dj.dj,
+        is_live: event_dj.is_live,
+        vj: event_dj.vj,
+        recording: event_dj.recording,
+      };
+    });
+  } else {
+    ui_event_obj.djs = [];
+  }
+  return ui_event_obj;
+};
+
 eventRouter.get("/:eventName", async (req, res) => {
   const event = await get_event(req.params.eventName);
   if (event instanceof Error) {
@@ -55,8 +75,9 @@ eventRouter.get("/:eventName", async (req, res) => {
       message: `Event ${req.params.eventName} does not exist`,
     });
   }
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  return res.send(event);
+  return res.send(ui_event_obj);
 });
 
 eventRouter.get("/", async (req, res) => {
@@ -74,7 +95,22 @@ eventRouter.post("/", async (req, res) => {
     });
   }
 
-  const error = await insert_into_events(new_event as IEventObject);
+  const event_djs = new_event.djs?.map((dj) => {
+    return {
+      event: new_event.name,
+      dj: dj.name,
+      is_live: dj.is_live,
+      vj: dj.vj,
+      recording: dj.recording,
+    } as IEventDjObject;
+  });
+
+  delete new_event.djs;
+
+  const error = await insert_into_events(
+    new_event as IEventObject,
+    event_djs ? event_djs : [],
+  );
   if (error !== undefined) {
     res.status(409);
     return res.send({
@@ -84,20 +120,33 @@ eventRouter.post("/", async (req, res) => {
   }
 
   const event = await get_event(new_event.name);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.post("/:eventName", async (req, res) => {
   const event_params: updateEventInterface = req.body;
+
+  const event_djs = event_params.djs?.map((dj) => {
+    return {
+      event: req.params.eventName,
+      dj: dj.name,
+      is_live: dj.is_live,
+      vj: dj.vj,
+      recording: dj.recording,
+    } as IEventDjObject;
+  });
+
+  delete event_params.djs;
+
   const update_params: IEventObject = Object.assign(
     {},
     { name: req.params.eventName },
     event_params,
-    { djs: event_params.djs as ILineupDjObject[] },
   );
 
-  const error = await update_event(update_params);
+  const error = await update_event(update_params, event_djs ? event_djs : []);
   if (error !== undefined) {
     res.status(404);
     return res.send({
@@ -107,8 +156,9 @@ eventRouter.post("/:eventName", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.delete("/:eventName", async (req, res) => {
@@ -156,8 +206,9 @@ eventRouter.post("/:eventName/dateTime", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.post("/:eventName/dj", async (req, res) => {
@@ -166,14 +217,20 @@ eventRouter.post("/:eventName/dj", async (req, res) => {
     res.status(400);
     return res.send({
       errorType: "InvalidInputError",
-      message: "The name field is required to add a DJ to an event's lineup.",
+      message: "The dj field is required to add a DJ to an event's lineup.",
     });
   }
 
-  const error = await add_event_dj(
-    req.params.eventName,
-    new_dj as ILineupDjObject,
-  );
+  const event_dj: IEventDjObject = {
+    event: req.params.eventName,
+    dj: req.body.name,
+    is_live: req.body.is_live,
+    vj: req.body.vj,
+    recording: req.body.recording,
+    position: -1,
+  };
+
+  const error = await add_event_dj(event_dj);
   if (error !== undefined) {
     res.status(404);
     return res.send({
@@ -183,8 +240,9 @@ eventRouter.post("/:eventName/dj", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.post("/:eventName/dj/:djName", async (req, res) => {
@@ -205,8 +263,9 @@ eventRouter.post("/:eventName/dj/:djName", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.delete("/:eventName/dj/:djName", async (req, res) => {
@@ -220,8 +279,9 @@ eventRouter.delete("/:eventName/dj/:djName", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.post("/:eventName/move-dj", async (req, res) => {
@@ -257,8 +317,9 @@ eventRouter.post("/:eventName/move-dj", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.post("/:eventName/promo", async (req, res) => {
@@ -272,7 +333,7 @@ eventRouter.post("/:eventName/promo", async (req, res) => {
     });
   }
 
-  const error = await add_event_promo(req.params.eventName, new_promo.name);
+  const error = await event_add_promo(req.params.eventName, new_promo.name);
   if (error !== undefined) {
     res.status(404);
     return res.send({
@@ -282,8 +343,9 @@ eventRouter.post("/:eventName/promo", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.delete("/:eventName/promo/:promoName", async (req, res) => {
@@ -300,8 +362,9 @@ eventRouter.delete("/:eventName/promo/:promoName", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.post("/:eventName/move-promo", async (req, res) => {
@@ -338,8 +401,9 @@ eventRouter.post("/:eventName/move-promo", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.post("/:eventName/set-theme", async (req, res) => {
@@ -362,8 +426,9 @@ eventRouter.post("/:eventName/set-theme", async (req, res) => {
   }
 
   const event = await get_event(req.params.eventName);
+  const ui_event_obj = await make_ui_event_object(event);
   res.status(200);
-  res.send(event);
+  res.send(ui_event_obj);
 });
 
 eventRouter.post("/:eventName/export", async (req, res) => {
@@ -391,6 +456,15 @@ eventRouter.get("/:eventName/export-summary", async (req, res) => {
     });
   }
 
+  const ui_event_obj = await make_ui_event_object(event_summary.event);
+  const summary: eventExportSummaryInterface = {
+    event: ui_event_obj,
+    djs: event_summary.djs,
+    promos: event_summary.promos,
+    theme: event_summary.theme,
+    files: event_summary.files,
+  };
+
   res.status(200);
-  res.send(event_summary);
+  res.send(summary);
 });

--- a/backend/src/openapi_routers/event_router.ts
+++ b/backend/src/openapi_routers/event_router.ts
@@ -82,7 +82,12 @@ eventRouter.get("/:eventName", async (req, res) => {
 
 eventRouter.get("/", async (req, res) => {
   res.status(200);
-  return res.send(await read_events_table());
+  const event_objects = await read_events_table();
+  const event_interfaces = [];
+  for (const event_object of event_objects) {
+    event_interfaces.push(await make_ui_event_object(event_object));
+  }
+  return res.send(event_interfaces);
 });
 
 eventRouter.post("/", async (req, res) => {

--- a/backend/src/tables.ts
+++ b/backend/src/tables.ts
@@ -8,10 +8,20 @@ export class Table {
   name: string;
   definitions: IColumnDefinition[];
   columns: string[];
-  constructor(name: string, definitions: IColumnDefinition[]) {
+  primary_key: string;
+  constructor(
+    name: string,
+    definitions: IColumnDefinition[],
+    pkey_definition?: string,
+  ) {
     this.name = name;
     this.definitions = definitions;
     this.columns = definitions.map((col) => col.name);
+    if (pkey_definition) {
+      this.primary_key = pkey_definition;
+    } else {
+      this.primary_key = this.columns[0];
+    }
   }
 
   private definitions_to_string = () => {
@@ -39,11 +49,24 @@ export class Table {
   }
 
   public get_single(primary_key: string) {
-    return `SELECT * FROM ${this.name} WHERE ${this.columns[0]} = '${primary_key}';`;
+    // In lieu of actually keeping track, remove later
+    if (this.primary_key === this.columns[0]) {
+      return `SELECT * FROM ${this.name} WHERE ${this.primary_key} = '${primary_key}';`;
+    } else {
+      return `SELECT * FROM ${this.name} WHERE ${this.primary_key} = ${primary_key};`;
+    }
   }
 
   public insert_into(values: string) {
     return `INSERT INTO ${this.name} VALUES ${values};`;
+  }
+
+  public delete_entry(primary_key: string) {
+    if (this.primary_key === this.columns[0]) {
+      return `DELETE FROM ${this.name} WHERE ${this.primary_key} = '${primary_key}'`;
+    } else {
+      return `DELETE FROM ${this.name} WHERE ${this.primary_key} = ${primary_key}`;
+    }
   }
 }
 
@@ -53,11 +76,12 @@ export const EVENTS_TABLE_NAME = "events";
 export const THEMES_TABLE_NAME = "themes";
 export const FILES_TABLE_NAME = "files";
 export const APP_THEMES_TABLE_NAME = "app_themes";
-export const EVENT_DJ_TABLE_NAME = "event_djs";
+export const EVENT_DJS_TABLE_NAME = "event_djs";
 export const DJS_TABLE: Table = new Table(DJS_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
+    no_updates: true,
   },
   {
     name: "logo",
@@ -105,10 +129,7 @@ export const EVENTS_TABLE: Table = new Table(EVENTS_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
-  },
-  {
-    name: "djs",
-    type: `JSONB`,
+    no_updates: true,
   },
   {
     name: "promos",
@@ -136,6 +157,7 @@ export const THEMES_TABLE: Table = new Table(THEMES_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
+    no_updates: true,
   },
   {
     name: "overlay_file",
@@ -199,6 +221,7 @@ export const FILES_TABLE: Table = new Table(FILES_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
+    no_updates: true,
   },
   {
     name: "root",
@@ -223,36 +246,48 @@ export const APP_THEMES_TABLE: Table = new Table(APP_THEMES_TABLE_NAME, [
     type: `JSONB`,
   },
 ]);
-export const EVENT_DJ_TABLE: Table = new Table(EVENT_DJ_TABLE_NAME, [
-  {
-    name: "event",
-    type: "TEXT",
-    fkey: `${EVENTS_TABLE_NAME}(name)`,
-  },
-  {
-    name: "dj",
-    type: "TEXT",
-    fkey: `${DJS_TABLE_NAME}(name)`,
-  },
-  {
-    name: "event, dj",
-    type: "PRIMARY KEY",
-    multi_col: true,
-  },
-  {
-    name: "is_live",
-    type: "BOOLEAN",
-  },
-  {
-    name: "recording",
-    type: "TEXT",
-    fkey: `${FILES_TABLE_NAME}(name)`,
-  },
-  {
-    name: "vj",
-    type: "TEXT",
-  },
-]);
+// TODO: add pkey to col, remove PRIMARY KEY from type and handle logic/formatting in the object
+export const EVENT_DJS_TABLE: Table = new Table(
+  EVENT_DJS_TABLE_NAME,
+  [
+    {
+      name: "event",
+      type: "TEXT",
+      fkey: `${EVENTS_TABLE_NAME}(name)`,
+      no_updates: true,
+    },
+    {
+      name: "dj",
+      type: "TEXT",
+      fkey: `${DJS_TABLE_NAME}(name)`,
+      no_updates: true,
+    },
+    {
+      name: "event, dj",
+      type: "PRIMARY KEY",
+      multi_col: true,
+      no_updates: true,
+    },
+    {
+      name: "is_live",
+      type: "BOOLEAN",
+    },
+    {
+      name: "recording",
+      type: "TEXT",
+      fkey: `${FILES_TABLE_NAME}(name)`,
+    },
+    {
+      name: "vj",
+      type: "TEXT",
+    },
+    {
+      name: "position",
+      type: "SMALLINT",
+    },
+  ],
+  "(event, dj)",
+);
 export const ALL_TABLES = [
   FILES_TABLE,
   THEMES_TABLE,
@@ -260,5 +295,5 @@ export const ALL_TABLES = [
   DJS_TABLE,
   EVENTS_TABLE,
   APP_THEMES_TABLE,
-  EVENT_DJ_TABLE,
+  EVENT_DJS_TABLE,
 ];

--- a/backend/src/tables.ts
+++ b/backend/src/tables.ts
@@ -45,7 +45,7 @@ export class Table {
   }
 
   public select() {
-    return `SELECT * FROM ${this.name};`;
+    return `SELECT * FROM ${this.name} ORDER BY ${this.primary_key} asc;`;
   }
 
   public get_single(primary_key: string) {

--- a/backend/src/tables.ts
+++ b/backend/src/tables.ts
@@ -18,6 +18,8 @@ export class Table {
     const def_strings = this.definitions.map((def) => {
       if (def.fkey) {
         return `${def.name} ${def.type} references ${def.fkey}`;
+      } else if (def.multi_col) {
+        return `${def.type} (${def.name})`;
       }
       return `${def.name} ${def.type}`;
     });
@@ -51,6 +53,7 @@ export const EVENTS_TABLE_NAME = "events";
 export const THEMES_TABLE_NAME = "themes";
 export const FILES_TABLE_NAME = "files";
 export const APP_THEMES_TABLE_NAME = "app_themes";
+export const EVENT_DJ_TABLE_NAME = "event_djs";
 export const DJS_TABLE: Table = new Table(DJS_TABLE_NAME, [
   {
     name: "name",
@@ -220,6 +223,36 @@ export const APP_THEMES_TABLE: Table = new Table(APP_THEMES_TABLE_NAME, [
     type: `JSONB`,
   },
 ]);
+export const EVENT_DJ_TABLE: Table = new Table(EVENT_DJ_TABLE_NAME, [
+  {
+    name: "event",
+    type: "TEXT",
+    fkey: `${EVENTS_TABLE_NAME}(name)`,
+  },
+  {
+    name: "dj",
+    type: "TEXT",
+    fkey: `${DJS_TABLE_NAME}(name)`,
+  },
+  {
+    name: "event, dj",
+    type: "PRIMARY KEY",
+    multi_col: true,
+  },
+  {
+    name: "is_live",
+    type: "BOOLEAN",
+  },
+  {
+    name: "recording",
+    type: "TEXT",
+    fkey: `${FILES_TABLE_NAME}(name)`,
+  },
+  {
+    name: "vj",
+    type: "TEXT",
+  },
+]);
 export const ALL_TABLES = [
   FILES_TABLE,
   THEMES_TABLE,
@@ -227,4 +260,5 @@ export const ALL_TABLES = [
   DJS_TABLE,
   EVENTS_TABLE,
   APP_THEMES_TABLE,
+  EVENT_DJ_TABLE,
 ];

--- a/backend/src/tables.ts
+++ b/backend/src/tables.ts
@@ -235,6 +235,7 @@ export const APP_THEMES_TABLE: Table = new Table(APP_THEMES_TABLE_NAME, [
   {
     name: "name",
     type: "TEXT PRIMARY KEY",
+    no_updates: true,
   },
   {
     name: "style",

--- a/backend/src/tables.ts
+++ b/backend/src/tables.ts
@@ -89,11 +89,6 @@ export const DJS_TABLE: Table = new Table(DJS_TABLE_NAME, [
     fkey: `${FILES_TABLE_NAME}(name)`,
   },
   {
-    name: "recording",
-    type: "TEXT",
-    fkey: `${FILES_TABLE_NAME}(name)`,
-  },
-  {
     name: "rtmp_server",
     type: "TEXT",
   },

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -4,6 +4,7 @@ export interface IColumnDefinition {
   name: string;
   type: string;
   fkey?: string;
+  multi_col?: boolean;
 }
 
 export interface IFileObject {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -5,6 +5,7 @@ export interface IColumnDefinition {
   type: string;
   fkey?: string;
   multi_col?: boolean;
+  no_updates?: boolean;
 }
 
 export interface IFileObject {
@@ -32,7 +33,6 @@ export interface IThemeObject {
 
 export interface IEventObject {
   name: string;
-  djs?: ILineupDjObject[];
   promos?: string[];
   theme?: string;
   date?: string;
@@ -43,7 +43,6 @@ export interface IEventObject {
 export interface IDjObject {
   name: string;
   logo?: string;
-  recording?: string;
   rtmp_server?: string;
   rtmp_key?: string;
   public_name?: string;
@@ -56,10 +55,21 @@ export interface IPromoObject {
   promo_file?: string;
 }
 
+// Now only for UI use
 export interface ILineupDjObject {
   name: string;
   is_live?: boolean;
   vj?: string;
+  recording?: string;
+}
+
+export interface IEventDjObject {
+  event: string;
+  dj: string;
+  position: number;
+  is_live?: boolean;
+  vj?: string;
+  recording?: string;
 }
 
 export interface IExportDjineupData {

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '1.0'
-
 services:
 
   db:

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,7 @@ services:
       timeout: 5s
       retries: 10
     volumes:
-      - postgres:/data/postgres
+      - postgres:/var/lib/postgresql/data
     networks:
       - private
 

--- a/frontend-svelte-5/src/lib/components/ui/file-objects-sheet/file-objects-sheet.svelte
+++ b/frontend-svelte-5/src/lib/components/ui/file-objects-sheet/file-objects-sheet.svelte
@@ -27,9 +27,11 @@
 	import type { Promotion } from '$lib/promotionsController';
 	import type { Theme } from '$lib/themeController';
 	import DeleteConfirmation from '$lib/components/ui/delete-confirmation/delete-confirmation.svelte';
+	import type { EventDj } from '$lib/eventController';
 
 	type Props = {
 		dj?: DJ;
+		event_dj?: EventDj;
 		promo?: Promotion;
 		theme?: Theme;
 		file_type: 'logos' | 'recordings' | 'theme-overlay' | 'theme-op' | 'theme-ed';
@@ -38,6 +40,7 @@
 
 	let {
 		dj = $bindable(),
+		event_dj = $bindable(),
 		promo = $bindable(),
 		theme = $bindable(),
 		file_type,
@@ -87,27 +90,25 @@
 		file_sheet_open = false;
 		file_sheet_open = true;
 		if (dj !== undefined) {
-			if (file_type === 'logos') {
-				files_promise = getAllLogos();
-				files_promise
-					.then((logos) => {
-						files = logos.slice().sort(sortFiles);
-						if (dj.logo) {
-							selected_file = logos.filter((logo) => logo.name === dj.logo)[0];
-						}
-					})
-					.catch((e) => console.log(e));
-			} else {
-				files_promise = getAllRecordings();
-				files_promise
-					.then((recs) => {
-						files = recs.slice().sort(sortFiles);
-						if (dj.recording) {
-							selected_file = recs.filter((rec) => rec.name === dj.recording)[0];
-						}
-					})
-					.catch((e) => console.log(e));
-			}
+			files_promise = getAllLogos();
+			files_promise
+				.then((logos) => {
+					files = logos.slice().sort(sortFiles);
+					if (dj.logo) {
+						selected_file = logos.filter((logo) => logo.name === dj.logo)[0];
+					}
+				})
+				.catch((e) => console.log(e));
+		} else if (event_dj !== undefined) {
+			files_promise = getAllRecordings();
+			files_promise
+				.then((recs) => {
+					files = recs.slice().sort(sortFiles);
+					if (event_dj.recording) {
+						selected_file = recs.filter((rec) => rec.name === event_dj.recording)[0];
+					}
+				})
+				.catch((e) => console.log(e));
 		} else if (promo !== undefined) {
 			files_promise = getAllRecordings();
 			files_promise
@@ -176,11 +177,9 @@
 	const deleteFile = async () => {
 		await deleteSingleFile(selected_file.name);
 		if (dj !== undefined) {
-			if (file_type === 'logos' && dj.logo === selected_file.name) {
-				dj.logo = '';
-			} else if (dj.recording === selected_file.name) {
-				dj.recording = '';
-			}
+			if (dj.logo === selected_file.name) dj.logo = '';
+		} else if (event_dj !== undefined) {
+			if (event_dj.recording === selected_file.name) event_dj.recording = '';
 		} else if (promo !== undefined) {
 			if (promo.promo_file === selected_file.name) promo.promo_file = '';
 		} else if (theme !== undefined) {
@@ -233,13 +232,11 @@
 
 	const createFile = async () => {
 		if (dj !== undefined) {
-			if (file_type === 'logos') {
-				dj.logo = create_file_name;
-				await addLogoFile(create_file_name);
-			} else {
-				dj.recording = create_file_name;
-				await addRecordingFile(create_file_name);
-			}
+			dj.logo = create_file_name;
+			await addLogoFile(create_file_name);
+		} else if (event_dj !== undefined) {
+			event_dj.recording = create_file_name;
+			await addRecordingFile(create_file_name);
 		} else if (promo !== undefined) {
 			promo.promo_file = create_file_name;
 			await addRecordingFile(create_file_name);

--- a/frontend-svelte-5/src/lib/components/ui/file-objects-sheet/file-objects-sheet.svelte
+++ b/frontend-svelte-5/src/lib/components/ui/file-objects-sheet/file-objects-sheet.svelte
@@ -17,7 +17,6 @@
 	import LoaderCircle from 'lucide-svelte/icons/loader-circle';
 	import CircleCheckBig from 'lucide-svelte/icons/circle-check-big';
 	import Ban from 'lucide-svelte/icons/ban';
-	import { staticAssetsBase } from '$lib/utils';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import type { DJ } from '$lib/djController';
@@ -72,6 +71,8 @@
 			return 'Select Theme File';
 		}
 	});
+
+	const staticAssetsBase = `http://${location.hostname}:4004`;
 
 	const selectFile = (file: File) => {
 		selected_file = file;

--- a/frontend-svelte-5/src/lib/components/ui/ledger-table/ledger-dj-columns.ts
+++ b/frontend-svelte-5/src/lib/components/ui/ledger-table/ledger-dj-columns.ts
@@ -55,24 +55,6 @@ export const createCols = (ledger_path: string, delete_function: (name: string) 
 			}
 		},
 		{
-			accessorKey: 'recording',
-			header: ({ column }) =>
-				renderComponent(DataTableNameButton, {
-					name: 'Recording',
-					onclick: () => column.toggleSorting(column.getIsSorted() === 'asc')
-				}),
-			cell: ({ row }) => {
-				return renderSnippet(CheckValue, row.original.recording);
-			},
-			sortingFn: (rowA, rowB) => {
-				return rowA.original.recording && rowB.original.recording
-					? 0
-					: rowA.original.recording
-						? -1
-						: 1;
-			}
-		},
-		{
 			id: 'actions',
 			cell: ({ row }) => {
 				return renderComponent(DataTableActions, {

--- a/frontend-svelte-5/src/lib/components/ui/local-file-browser/local-file-browser.svelte
+++ b/frontend-svelte-5/src/lib/components/ui/local-file-browser/local-file-browser.svelte
@@ -14,7 +14,6 @@
 	import FileImage from 'lucide-svelte/icons/file-image';
 	import FileVideo from 'lucide-svelte/icons/file-video';
 	import Folder from 'lucide-svelte/icons/folder';
-	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import { Input } from '$lib/components/ui/input/index.js';
 
 	const isImageSource = (source_path: string) => {
@@ -193,7 +192,7 @@
 			</Dialog.Title>
 			<Dialog.Description>
 				<div class="flex flex-col items-center justify-between md:flex-row">
-					<div class="table-container h-96 overflow-y-auto">
+					<div class="table-container h-96 overflow-y-auto md:h-[40vh]">
 						<Table.Root>
 							<Table.Header>
 								<Table.Row>
@@ -223,20 +222,21 @@
 							</Table.Body>
 						</Table.Root>
 					</div>
-					<!-- <Separator orientation="vertical" class="my-4"></Separator> -->
-					{#if file_browser_selected_file?.name && !file_browser_selected_file.is_dir}
-						{#if isImageSource(file_browser_preview_path)}
-							<img
-								class="mx-auto max-h-80 max-w-80"
-								src={file_browser_preview_path}
-								alt="Preview"
-							/>
-						{:else}
-							<video class="mx-auto max-h-80 max-w-80" controls src={file_browser_preview_path}
-								><track kind="captions" /></video
-							>
+					<div class="mx-auto">
+						{#if file_browser_selected_file?.name && !file_browser_selected_file.is_dir}
+							{#if isImageSource(file_browser_preview_path)}
+								<img
+									class="h-80 w-80 object-scale-down"
+									src={file_browser_preview_path}
+									alt="Preview"
+								/>
+							{:else}
+								<video class="h-80 w-80 object-scale-down" controls src={file_browser_preview_path}
+									><track kind="captions" /></video
+								>
+							{/if}
 						{/if}
-					{/if}
+					</div>
 				</div>
 			</Dialog.Description>
 		</Dialog.Header>

--- a/frontend-svelte-5/src/lib/components/ui/local-file-browser/local-file-browser.svelte
+++ b/frontend-svelte-5/src/lib/components/ui/local-file-browser/local-file-browser.svelte
@@ -16,7 +16,6 @@
 	import Folder from 'lucide-svelte/icons/folder';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import { Input } from '$lib/components/ui/input/index.js';
-	import { staticAssetsBase } from '$lib/utils';
 
 	const isImageSource = (source_path: string) => {
 		return source_path.match(/\.(jpeg|jpg|gif|png)$/) != null;
@@ -36,6 +35,8 @@
 	let file_browser_selected_file: LocalFile = $state({} as LocalFile);
 	let file_browser_files: LocalFile[] = $state([]);
 	let file_browser_preview_path: string = $state('');
+
+	const staticAssetsBase = `http://${location.hostname}:4004`;
 
 	function localfileCompare(a: LocalFile, b: LocalFile) {
 		return a.is_dir && b.is_dir ? 0 : a.is_dir ? -1 : 1;
@@ -191,8 +192,8 @@
 				</div>
 			</Dialog.Title>
 			<Dialog.Description>
-				<div class="flex flex-col items-center justify-between sm:flex-row">
-					<div class="table-container h-96 basis-1/2 overflow-y-auto">
+				<div class="flex flex-col items-center justify-between md:flex-row">
+					<div class="table-container h-96 overflow-y-auto">
 						<Table.Root>
 							<Table.Header>
 								<Table.Row>
@@ -222,7 +223,7 @@
 							</Table.Body>
 						</Table.Root>
 					</div>
-					<Separator orientation="vertical" class="my-4"></Separator>
+					<!-- <Separator orientation="vertical" class="my-4"></Separator> -->
 					{#if file_browser_selected_file?.name && !file_browser_selected_file.is_dir}
 						{#if isImageSource(file_browser_preview_path)}
 							<img

--- a/frontend-svelte-5/src/lib/djController.ts
+++ b/frontend-svelte-5/src/lib/djController.ts
@@ -19,6 +19,13 @@ export interface DJ {
 	discord_id: string;
 }
 
+export interface DjEvent {
+	event: string;
+	is_live: boolean;
+	vj: string;
+	date: string;
+}
+
 /**
  * Represents a minimal DJ object containing some properties.
  * @typedef {Object} DjMin
@@ -61,6 +68,20 @@ export async function getMin(fetch_fn?: typeof fetch): Promise<DjMin[]> {
 export async function getSingle(dj_name: string, fetch_fn?: typeof fetch): Promise<DJ | undefined> {
 	if (fetch_fn) return await openapiGet('dj/' + dj_name, undefined, fetch_fn);
 	return await openapiGet('dj/' + dj_name);
+}
+
+/**
+ * Fetches events for a DJ by its name from the API.
+ * @param {string} dj_name - The name of the DJ to fetch.
+ * @param {typeof fetch} [fetch_fn] - Optional custom fetch function for testing purposes.
+ * @returns {Promise<DjEvent[]>} A list of DjEvent objects.
+ */
+export async function getSingleEvents(
+	dj_name: string,
+	fetch_fn?: typeof fetch
+): Promise<DjEvent[]> {
+	if (fetch_fn) return await openapiGet('dj/' + dj_name + '/events', undefined, fetch_fn);
+	return await openapiGet('dj/' + dj_name + '/events');
 }
 
 /**

--- a/frontend-svelte-5/src/lib/djController.ts
+++ b/frontend-svelte-5/src/lib/djController.ts
@@ -5,7 +5,6 @@ import { openapiGet, openapiPostBody, openapiDelete } from './utils';
  * @typedef {Object} DJ
  * @property {string} name - The name of the DJ.
  * @property {string|null} logo - URL for the DJ's logo, can be null.
- * @property {string|null} recording - URL for a recording by this DJ, can be null.
  * @property {string} rtmp_server - The RTMP server URL for the DJ.
  * @property {string} rtmp_key - The key used on the RTMP server.
  * @property {string} public_name - A public name or alias of the DJ.
@@ -14,7 +13,6 @@ import { openapiGet, openapiPostBody, openapiDelete } from './utils';
 export interface DJ {
 	name: string;
 	logo: string | null;
-	recording: string | null;
 	rtmp_server: string;
 	rtmp_key: string;
 	public_name: string;
@@ -26,13 +24,11 @@ export interface DJ {
  * @typedef {Object} DjMin
  * @property {string} name - The name of the DJ.
  * @property {string} logo - URL for the DJ's logo.
- * @property {string} recording - URL for a recording by this DJ.
  * @property {string} rtmp_server - The RTMP server URL for the DJ.
  */
 export interface DjMin {
 	name: string;
 	logo: string;
-	recording: string;
 	rtmp_server: string;
 }
 
@@ -94,7 +90,6 @@ export async function addSingle(name: string): Promise<DJ | undefined> {
 export async function updateSingle(
 	name: string,
 	logo: string | null,
-	recording: string | null,
 	rtmp_server: string,
 	rtmp_key: string,
 	public_name: string,
@@ -102,7 +97,6 @@ export async function updateSingle(
 ): Promise<DJ | undefined> {
 	const body = {
 		logo: logo,
-		recording: recording,
 		rtmp_server: rtmp_server,
 		rtmp_key: rtmp_key,
 		public_name: public_name,

--- a/frontend-svelte-5/src/lib/eventController.ts
+++ b/frontend-svelte-5/src/lib/eventController.ts
@@ -10,11 +10,13 @@ import { openapiGet, openapiPostBody, openapiDelete, openapiPost } from './utils
  * @property {string} name - The name of the DJ.
  * @property {boolean} is_live - Indicates if the DJ is currently live.
  * @property {string} vj - The VJ associated with the DJ.
+ * @property {string|null} recording - The recording file associated with the DJ for this event.
  */
 export interface EventDj {
 	name: string;
 	is_live: boolean;
 	vj: string;
+	recording: string | null;
 }
 
 /**

--- a/frontend-svelte-5/src/lib/utils.ts
+++ b/frontend-svelte-5/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { writable } from 'svelte/store';
+import { page } from '$app/state';
+import { building, dev } from '$app/environment';
 
 /**
  * Represents an error message object containing status information.
@@ -26,23 +28,22 @@ export interface LineupItem {
 	selected: boolean;
 }
 
-// const serverUrl = `${page.url.protocol}//${page.url.hostname}:4004`;
-// export const staticAssetsBase = `${page.url.protocol}//${page.url.hostname}:4004`;
+// Commenting these out as their references have been replaced with location.hostname, which needs to be called after a page is loaded.
 /**
  * The base URL of the server.
  * @type {string}
  */
-const serverUrl = 'http://localhost:4004';
+// export let serverUrl = 'http://localhost:4004';
 /**
  * The base URL for static assets, typically the same as the server URL.
  * @type {string}
  */
-export const staticAssetsBase = 'http://localhost:4004';
+// export let staticAssetsBase = 'http://localhost:4004';
 /**
  * The base URL for OpenAPI requests including protocol and hostname.
  * @type {string}
  */
-const openapiUrl = `${serverUrl}/openapi`;
+// const openapiUrl = `${serverUrl}/openapi`;
 
 /**
  * A function to merge class names with Tailwind CSS classes.
@@ -116,7 +117,7 @@ export function isImageSource(source_path: string) {
  * @returns {Promise<any>} - A promise that resolves with the JSON response on success, rejects otherwise.
  */
 export async function openapiGet(url: string, bubble_error = true, fetch_fn = fetch) {
-	const request = fetch_fn(`${openapiUrl}/${url}`, {
+	const request = fetch_fn(`http://${location.hostname}:4004/openapi/${url}`, {
 		method: 'GET'
 	});
 
@@ -134,7 +135,7 @@ export async function openapiGet(url: string, bubble_error = true, fetch_fn = fe
  * @returns {Promise<any>} - A promise that resolves with the JSON response on success, rejects otherwise.
  */
 export async function openapiPostBody(url: string, body: {}) {
-	const request = fetch(`${openapiUrl}/${url}`, {
+	const request = fetch(`http://${location.hostname}:4004/openapi/${url}`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json'
@@ -161,7 +162,7 @@ export async function openapiPostBody(url: string, body: {}) {
  * @returns {Promise<boolean>} - A promise that resolves with true on success, rejects otherwise.
  */
 export async function openapiPost(url: string) {
-	const request = fetch(`${openapiUrl}/${url}`, {
+	const request = fetch(`http://${location.hostname}:4004/openapi/${url}`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json'
@@ -184,7 +185,7 @@ export async function openapiPost(url: string) {
  * @returns {Promise<boolean>} - A promise that resolves with true on success, rejects otherwise.
  */
 export async function openapiDelete(url: string) {
-	const request = fetch(`${openapiUrl}/${url}`, {
+	const request = fetch(`http://${location.hostname}:4004/openapi/${url}`, {
 		method: 'DELETE'
 	});
 	const response = await request;

--- a/frontend-svelte-5/src/routes/djs/[slug]/+page.svelte
+++ b/frontend-svelte-5/src/routes/djs/[slug]/+page.svelte
@@ -22,15 +22,7 @@
 	let fileObjectSheetInstance: FileObjectsSheet;
 
 	const submitChanges = () => {
-		updateSingle(
-			dj.name,
-			dj.logo,
-			dj.recording,
-			dj.rtmp_server,
-			dj.rtmp_key,
-			dj.public_name,
-			dj.discord_id
-		)
+		updateSingle(dj.name, dj.logo, dj.rtmp_server, dj.rtmp_key, dj.public_name, dj.discord_id)
 			.then(() => {
 				pushToLog({
 					statusCode: 200,
@@ -95,25 +87,12 @@
 		fileObjectSheetInstance.openFileSheet();
 	};
 
-	const selectRecording = () => {
-		file_type = 'recordings';
-		fileObjectSheetInstance.openFileSheet();
-	};
-
 	const submitFile = (selected_file: File) => {
-		if (file_type === 'logos') {
-			dj.logo = selected_file.name;
-		} else {
-			dj.recording = selected_file.name;
-		}
+		dj.logo = selected_file.name;
 	};
 
 	const unsetLogoFile = () => {
 		dj.logo = null;
-	};
-
-	const unsetRecordingFile = () => {
-		dj.recording = null;
 	};
 </script>
 
@@ -121,14 +100,6 @@
 	{dj.name}
 </h1>
 
-<DjTable
-	bind:dj
-	{submitChanges}
-	{deleteDj}
-	{selectLogo}
-	{selectRecording}
-	{unsetLogoFile}
-	{unsetRecordingFile}
-/>
+<DjTable bind:dj {submitChanges} {deleteDj} {selectLogo} {unsetLogoFile} />
 
 <FileObjectsSheet bind:dj {file_type} {submitFile} bind:this={fileObjectSheetInstance} />

--- a/frontend-svelte-5/src/routes/djs/[slug]/+page.svelte
+++ b/frontend-svelte-5/src/routes/djs/[slug]/+page.svelte
@@ -17,6 +17,7 @@
 
 	let { data }: PageProps = $props();
 	let dj = $state(data.dj);
+	let events = data.events;
 	let file_type: 'logos' | 'recordings' = $state('logos');
 
 	let fileObjectSheetInstance: FileObjectsSheet;
@@ -100,6 +101,6 @@
 	{dj.name}
 </h1>
 
-<DjTable bind:dj {submitChanges} {deleteDj} {selectLogo} {unsetLogoFile} />
+<DjTable bind:dj {events} {submitChanges} {deleteDj} {selectLogo} {unsetLogoFile} />
 
 <FileObjectsSheet bind:dj {file_type} {submitFile} bind:this={fileObjectSheetInstance} />

--- a/frontend-svelte-5/src/routes/djs/[slug]/+page.ts
+++ b/frontend-svelte-5/src/routes/djs/[slug]/+page.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
-import { getSingle } from '$lib/djController';
+import { getSingle, getSingleEvents } from '$lib/djController';
 
 export const load: PageLoad = async ({ fetch, params }) => {
 	const real_name = decodeURI(params.slug);
@@ -12,7 +12,10 @@ export const load: PageLoad = async ({ fetch, params }) => {
 	}
 	if (dj_data === undefined) error(404, `DJ ${real_name} not found`);
 
+	let dj_event_data = await getSingleEvents(real_name, fetch);
+
 	return {
-		dj: dj_data
+		dj: dj_data,
+		events: dj_event_data
 	};
 };

--- a/frontend-svelte-5/src/routes/djs/[slug]/dj-table.svelte
+++ b/frontend-svelte-5/src/routes/djs/[slug]/dj-table.svelte
@@ -6,18 +6,31 @@
 	import FileX from 'lucide-svelte/icons/file-x';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { RTMP_SERVERS } from '$lib/utils';
-	import type { DJ } from '$lib/djController';
+	import type { DJ, DjEvent } from '$lib/djController';
 	import DeleteConfirmation from '$lib/components/ui/delete-confirmation/delete-confirmation.svelte';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import Wifi from 'lucide-svelte/icons/wifi';
+	import Film from 'lucide-svelte/icons/film';
 
 	type Props = {
 		dj: DJ;
+		events: DjEvent[];
 		submitChanges: () => void;
 		deleteDj: () => void;
 		selectLogo: () => void;
 		unsetLogoFile: () => void;
 	};
 
-	let { dj = $bindable(), submitChanges, deleteDj, selectLogo, unsetLogoFile }: Props = $props();
+	let {
+		dj = $bindable(),
+		events,
+		submitChanges,
+		deleteDj,
+		selectLogo,
+		unsetLogoFile
+	}: Props = $props();
+
+	console.log(events);
 
 	const rtmpTriggerContent = $derived(
 		RTMP_SERVERS.find((r) => r.id === dj.rtmp_server && r.id !== '')?.name ?? 'RTMP Server'
@@ -94,6 +107,38 @@
 		<Button class="w-full" onclick={submitChanges}>Save</Button>
 		<Button variant="destructive" class="w-full" onclick={openDeleteConfirmation}>Delete</Button>
 	</div>
+
+	<Table.Root>
+		<Table.Caption>Events this DJ is part of.</Table.Caption>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head class="w-[100px]">#</Table.Head>
+				<Table.Head>Event</Table.Head>
+				<Table.Head>Source</Table.Head>
+				<Table.Head>VJ</Table.Head>
+				<Table.Head>Date</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#each events as event, index}
+				<Table.Row>
+					<Table.Cell class="font-medium">{events.length - index}</Table.Cell>
+					<Table.Cell>
+						<a class="hover:underline" href="/events/{event.event}">{event.event}</a>
+					</Table.Cell>
+					<Table.Cell>
+						{#if event.is_live}
+							<Wifi class="mr-2 size-4 text-primary" />
+						{:else}
+							<Film class="mr-2 size-4 text-primary" />
+						{/if}
+					</Table.Cell>
+					<Table.Cell>{event.vj}</Table.Cell>
+					<Table.Cell>{event.date}</Table.Cell>
+				</Table.Row>
+			{/each}
+		</Table.Body>
+	</Table.Root>
 </div>
 
 <DeleteConfirmation

--- a/frontend-svelte-5/src/routes/djs/[slug]/dj-table.svelte
+++ b/frontend-svelte-5/src/routes/djs/[slug]/dj-table.svelte
@@ -3,7 +3,6 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import FileImage from 'lucide-svelte/icons/file-image';
-	import Film from 'lucide-svelte/icons/film';
 	import FileX from 'lucide-svelte/icons/file-x';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { RTMP_SERVERS } from '$lib/utils';
@@ -15,20 +14,10 @@
 		submitChanges: () => void;
 		deleteDj: () => void;
 		selectLogo: () => void;
-		selectRecording: () => void;
 		unsetLogoFile: () => void;
-		unsetRecordingFile: () => void;
 	};
 
-	let {
-		dj = $bindable(),
-		submitChanges,
-		deleteDj,
-		selectLogo,
-		selectRecording,
-		unsetLogoFile,
-		unsetRecordingFile
-	}: Props = $props();
+	let { dj = $bindable(), submitChanges, deleteDj, selectLogo, unsetLogoFile }: Props = $props();
 
 	const rtmpTriggerContent = $derived(
 		RTMP_SERVERS.find((r) => r.id === dj.rtmp_server && r.id !== '')?.name ?? 'RTMP Server'
@@ -68,22 +57,6 @@
 			</Button>
 		</div>
 		<p class="text-sm text-muted-foreground">{dj.logo ? `Current: ${dj.logo}` : 'No Logo Set'}</p>
-	</div>
-	<div class="flex w-full flex-col justify-between gap-1.5 py-4">
-		<Label for="discord-id">DJ Recording</Label>
-		<div class="flex flex-row">
-			<Button class="basis-1/2" variant="outline" onclick={selectRecording}>
-				<Film class="mr-2 h-4 w-4" />
-				Select Recording
-			</Button>
-			<Button class="basis-1/2" variant="secondary" onclick={unsetRecordingFile}>
-				<FileX class="mr-2 h-4 w-4" />
-				Unset
-			</Button>
-		</div>
-		<p class="text-sm text-muted-foreground">
-			{dj.recording ? `Current: ${dj.recording}` : 'No Recording Set'}
-		</p>
 	</div>
 
 	<div class="flex w-full flex-row justify-between gap-1.5 py-4">

--- a/frontend-svelte-5/src/routes/events/[slug]/event-dj-table.svelte
+++ b/frontend-svelte-5/src/routes/events/[slug]/event-dj-table.svelte
@@ -14,9 +14,12 @@
 	import Wifi from 'lucide-svelte/icons/wifi';
 	import WifiOff from 'lucide-svelte/icons/wifi-off';
 	import UserPen from 'lucide-svelte/icons/user-pen';
+	import Film from 'lucide-svelte/icons/film';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
 	import { flip } from 'svelte/animate';
 	import { cn } from '$lib/utils.js';
+	import { type File } from '$lib/fileController';
+	import FileObjectsSheet from '$lib/components/ui/file-objects-sheet/file-objects-sheet.svelte';
 
 	type Props = {
 		event_djs: EventDj[];
@@ -31,9 +34,13 @@
 	let edit_vj_text = $state('');
 	let edit_vj_dj: EventDj = $state({} as EventDj);
 
+	let edit_recording_dj: EventDj = $state({} as EventDj);
+
 	let dragging_index = 0;
 	let last_dragover_index = 0;
 	let is_dragging = false;
+
+	let fileObjectSheetInstance: FileObjectsSheet;
 
 	const changeEventDjLive = async (dj: EventDj) => {
 		dj.is_live = !dj.is_live;
@@ -44,6 +51,15 @@
 		edit_vj_dialogue_open = false;
 		edit_vj_text = dj.vj;
 		edit_vj_dialogue_open = true;
+	};
+
+	const changeEventDjRecording = async (dj: EventDj) => {
+		edit_recording_dj = dj;
+		fileObjectSheetInstance.openFileSheet();
+	};
+
+	const submitFile = (selected_file: File) => {
+		edit_recording_dj.recording = selected_file.name;
 	};
 
 	function handleDragStart(index: number, event: DragEvent) {
@@ -157,15 +173,22 @@
 									<DropdownMenu.Item onclick={() => changeEventDjLive(event_dj)}>
 										{#if event_dj.is_live}
 											<WifiOff class="mr-2 size-4" />
+											Set Pre-Recorded
 										{:else}
 											<Wifi class="mr-2 size-4" />
+											Set Live
 										{/if}
-										Toggle Live
 									</DropdownMenu.Item>
 									<DropdownMenu.Item onclick={() => changeEventDjVj(event_dj)}>
 										<UserPen class="mr-2 size-4" />
 										Edit VJ
 									</DropdownMenu.Item>
+									{#if !event_dj.is_live}
+										<DropdownMenu.Item onclick={() => changeEventDjRecording(event_dj)}>
+											<Film class="mr-2 size-4" />
+											Set Recording
+										</DropdownMenu.Item>
+									{/if}
 								</DropdownMenu.Group>
 								<DropdownMenu.Separator />
 								<DropdownMenu.Item onclick={() => window.open(`/djs/${event_dj.name}`, '_blank')}>
@@ -202,3 +225,10 @@
 		</Dialog.Content>
 	</Dialog.Root>
 </div>
+
+<FileObjectsSheet
+	event_dj={edit_recording_dj}
+	file_type={'recordings'}
+	{submitFile}
+	bind:this={fileObjectSheetInstance}
+/>

--- a/frontend-svelte-5/src/routes/events/[slug]/event-dj-table.svelte
+++ b/frontend-svelte-5/src/routes/events/[slug]/event-dj-table.svelte
@@ -44,6 +44,7 @@
 
 	const changeEventDjLive = async (dj: EventDj) => {
 		dj.is_live = !dj.is_live;
+		if (!dj.is_live) changeEventDjRecording(dj);
 	};
 
 	const changeEventDjVj = async (dj: EventDj) => {
@@ -128,7 +129,7 @@
 			<Table.Row>
 				<Table.Head class="w-[100px]">#</Table.Head>
 				<Table.Head>Name</Table.Head>
-				<Table.Head>Live</Table.Head>
+				<Table.Head>Source</Table.Head>
 				<Table.Head>VJ</Table.Head>
 				<Table.Head></Table.Head>
 			</Table.Row>
@@ -151,9 +152,19 @@
 					<Table.Cell>{event_dj.name}</Table.Cell>
 					<Table.Cell>
 						{#if event_dj.is_live}
-							<CircleCheckBig class="mr-2 size-4 text-primary" />
+							<div class="flex flex-row items-center text-center">
+								<Wifi class="mr-2 size-4 text-primary" />
+								<span>Live</span>
+							</div>
+						{:else if event_dj.recording}
+							<div class="flex flex-row items-center text-center">
+								<Film class="mr-2 size-4 text-primary" />
+								<span>{event_dj.recording}</span>
+							</div>
 						{:else}
-							<Ban class="mr-2 size-4 text-muted" />
+							<div class="flex flex-row items-center text-center">
+								<Ban class="mr-2 size-4 text-muted" />
+							</div>
 						{/if}
 					</Table.Cell>
 					<Table.Cell>{event_dj.vj}</Table.Cell>

--- a/frontend-svelte-5/src/routes/events/[slug]/event-dj-table.svelte
+++ b/frontend-svelte-5/src/routes/events/[slug]/event-dj-table.svelte
@@ -4,7 +4,6 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { type EventDj } from '$lib/eventController';
-	import CircleCheckBig from 'lucide-svelte/icons/circle-check-big';
 	import Ban from 'lucide-svelte/icons/ban';
 	import Plus from 'lucide-svelte/icons/plus';
 	import Ellipsis from 'lucide-svelte/icons/ellipsis';

--- a/frontend-svelte-5/src/routes/events/[slug]/event-table.svelte
+++ b/frontend-svelte-5/src/routes/events/[slug]/event-table.svelte
@@ -124,7 +124,9 @@
 
 	const submitLineupSelection = (new_items: string[]) => {
 		if (lineup_type === 'djs') {
-			new_items.forEach((name) => event.djs.push({ name: name, is_live: false, vj: '' }));
+			new_items.forEach((name) =>
+				event.djs.push({ name: name, is_live: false, vj: '', recording: null })
+			);
 		} else {
 			new_items.forEach((name) => event.promos.push(name));
 		}

--- a/frontend-svelte-5/src/routes/events/[slug]/export/+page.svelte
+++ b/frontend-svelte-5/src/routes/events/[slug]/export/+page.svelte
@@ -114,6 +114,15 @@
 															${files_map.get(dj_map.get(event_dj.name)?.logo || '')?.file_path}`}
 															alt="Preview"
 														/>
+														<span>
+															{files_map
+																.get(dj_map.get(event_dj.name)?.logo || '')
+																?.file_path.split('/')[
+																files_map
+																	.get(dj_map.get(event_dj.name)!.logo || '')!
+																	.file_path.split('/').length - 1
+															]}
+														</span>
 													{:else if files_map.get(dj_map.get(event_dj.name)?.logo || '')?.url_path}
 														<a
 															class="hover:underline"
@@ -166,6 +175,12 @@
 														>
 															<track kind="captions" />
 														</video>
+														<span>
+															{files_map.get(event_dj?.recording || '')?.file_path.split('/')[
+																files_map.get(event_dj!.recording || '')!.file_path.split('/')
+																	.length - 1
+															]}
+														</span>
 													{:else if files_map.get(event_dj?.recording || '')?.url_path}
 														<a
 															class="hover:underline"
@@ -253,6 +268,15 @@
 														>
 															<track kind="captions" />
 														</video>
+														<span>
+															{files_map
+																.get(promo_map.get(promo)?.promo_file || '')
+																?.file_path.split('/')[
+																files_map
+																	.get(promo_map.get(promo)!.promo_file || '')!
+																	.file_path.split('/').length - 1
+															]}
+														</span>
 													{:else if files_map.get(promo_map.get(promo)?.promo_file || '')?.url_path}
 														<a
 															class="hover:underline"
@@ -300,7 +324,7 @@
 
 	<Separator class="my-4"></Separator>
 
-	<div class="flex flex-col items-center justify-between md:flex-row">
+	<div class="flex flex-col items-center justify-between py-6 md:flex-row">
 		{#if data.event.theme}
 			<span>
 				Theme: {data.event.theme}
@@ -472,6 +496,11 @@
 										<track kind="captions" />
 									</video>
 								{/if}
+								<span>
+									{files_map.get(data.theme.starting_file)?.file_path.split('/')[
+										files_map.get(data.theme.starting_file)!.file_path.split('/').length - 1
+									]}
+								</span>
 							{:else}
 								<span> No file set. </span>
 							{/if}
@@ -514,6 +543,11 @@
 										<track kind="captions" />
 									</video>
 								{/if}
+								<span>
+									{files_map.get(data.theme.ending_file)?.file_path.split('/')[
+										files_map.get(data.theme.ending_file)!.file_path.split('/').length - 1
+									]}
+								</span>
 							{:else}
 								<span> No file set. </span>
 							{/if}
@@ -556,6 +590,11 @@
 										<track kind="captions" />
 									</video>
 								{/if}
+								<span>
+									{files_map.get(data.theme.overlay_file)?.file_path.split('/')[
+										files_map.get(data.theme.overlay_file)!.file_path.split('/').length - 1
+									]}
+								</span>
 							{:else}
 								<span> No file set. </span>
 							{/if}
@@ -571,6 +610,20 @@
 			No theme Set.
 		{/if}
 	</div>
+
+	{#if data.event.theme}
+		<div class="flex flex-row items-center justify-between">
+			{#each data.theme_errors as theme_error}
+				{#if theme_error !== undefined}
+					<Alert.Root variant="destructive">
+						<CircleAlert class="size-4" />
+						<Alert.Title>Error</Alert.Title>
+						<Alert.Description>{theme_error}</Alert.Description>
+					</Alert.Root>
+				{/if}
+			{/each}
+		</div>
+	{/if}
 
 	<Separator class="my-4"></Separator>
 

--- a/frontend-svelte-5/src/routes/events/[slug]/export/+page.svelte
+++ b/frontend-svelte-5/src/routes/events/[slug]/export/+page.svelte
@@ -85,96 +85,97 @@
 						</Table.Row>
 					</Table.Header>
 					<Table.Body>
-						{#each data.event.djs as dj}
+						{#each data.event.djs as event_dj}
 							<Table.Row>
 								<Table.Cell>
 									<Button
 										variant="link"
 										class="text-foreground"
-										onclick={() => goto(`/djs/${dj.name}`)}
+										onclick={() => goto(`/djs/${event_dj.name}`)}
 									>
-										{dj.name}
+										{event_dj.name}
 									</Button>
 								</Table.Cell>
 								<Table.Cell class="font-medium">
 									<div class="flex flex-row items-center text-center">
-										{#if dj_map.get(dj.name)?.logo}
+										{#if dj_map.get(event_dj.name)?.logo}
 											<HoverCard.Root>
 												<HoverCard.Trigger>
 													<div class="flex flex-row items-center text-center">
 														<FileImage class="mr-2 size-4 text-primary" />
-														<span>{dj_map.get(dj.name)?.logo}</span>
+														<span>{dj_map.get(event_dj.name)?.logo}</span>
 													</div>
 												</HoverCard.Trigger>
 												<HoverCard.Content>
-													{#if files_map.get(dj_map.get(dj.name)?.logo || '')?.file_path}
+													{#if files_map.get(dj_map.get(event_dj.name)?.logo || '')?.file_path}
 														<img
 															class="w-full"
 															src={`${staticAssetsBase}/logos/
-															${files_map.get(dj_map.get(dj.name)?.logo || '')?.file_path}`}
+															${files_map.get(dj_map.get(event_dj.name)?.logo || '')?.file_path}`}
 															alt="Preview"
 														/>
-													{:else if files_map.get(dj_map.get(dj.name)?.logo || '')?.url_path}
+													{:else if files_map.get(dj_map.get(event_dj.name)?.logo || '')?.url_path}
 														<a
 															class="hover:underline"
-															href={files_map.get(dj_map.get(dj.name)?.logo || '')?.url_path}
+															href={files_map.get(dj_map.get(event_dj.name)?.logo || '')?.url_path}
 														>
-															{files_map.get(dj_map.get(dj.name)?.logo || '')?.url_path}
+															{files_map.get(dj_map.get(event_dj.name)?.logo || '')?.url_path}
 														</a>
 													{:else}
 														<span>
-															No file/url set for {dj_map.get(dj.name)?.logo}
+															No file/url set for {dj_map.get(event_dj.name)?.logo}
 														</span>
 													{/if}
 												</HoverCard.Content>
 											</HoverCard.Root>
-										{:else if dj_map.get(dj.name)?.public_name}
+										{:else if dj_map.get(event_dj.name)?.public_name}
 											<Type class="mr-2 size-4 text-primary" />
-											<span>{dj_map.get(dj.name)?.public_name}</span>
+											<span>{dj_map.get(event_dj.name)?.public_name}</span>
 										{:else}
 											<Type class="mr-2 size-4 text-primary" />
-											<span>{dj.name}</span>
+											<span>{event_dj.name}</span>
 										{/if}
 									</div>
 								</Table.Cell>
 								<Table.Cell class="font-medium">
 									<div class="flex flex-row items-center text-center">
-										{#if dj.is_live}
-											{#if dj_map.get(dj.name)?.rtmp_server && dj_map.get(dj.name)?.rtmp_key}
+										{#if event_dj.is_live}
+											{#if dj_map.get(event_dj.name)?.rtmp_server && dj_map.get(event_dj.name)?.rtmp_key}
 												<Wifi class="mr-2 size-4 text-primary" />
 												<span
-													>{dj_map.get(dj.name)?.rtmp_server}:{dj_map.get(dj.name)?.rtmp_key}</span
+													>{dj_map.get(event_dj.name)?.rtmp_server}:{dj_map.get(event_dj.name)
+														?.rtmp_key}</span
 												>
 											{:else}
 												<Ban class="mr-2 size-4 text-primary" />
 											{/if}
-										{:else if dj_map.get(dj.name)?.recording}
+										{:else if event_dj?.recording}
 											<HoverCard.Root>
 												<HoverCard.Trigger>
 													<div class="flex flex-row items-center text-center">
 														<FileVideo class="mr-2 size-4 text-primary" />
-														<span>{dj_map.get(dj.name)?.recording}</span>
+														<span>{event_dj?.recording}</span>
 													</div>
 												</HoverCard.Trigger>
 												<HoverCard.Content>
-													{#if files_map.get(dj_map.get(dj.name)?.recording || '')?.file_path}
+													{#if files_map.get(event_dj?.recording || '')?.file_path}
 														<video
 															controls
 															src={`${staticAssetsBase}/recordings/
-																${files_map.get(dj_map.get(dj.name)?.recording || '')?.file_path}`}
+																${files_map.get(event_dj?.recording || '')?.file_path}`}
 														>
 															<track kind="captions" />
 														</video>
-													{:else if files_map.get(dj_map.get(dj.name)?.recording || '')?.url_path}
+													{:else if files_map.get(event_dj?.recording || '')?.url_path}
 														<a
 															class="hover:underline"
-															href={files_map.get(dj_map.get(dj.name)?.recording || '')?.url_path}
+															href={files_map.get(event_dj?.recording || '')?.url_path}
 														>
-															{files_map.get(dj_map.get(dj.name)?.recording || '')?.url_path}
+															{files_map.get(event_dj?.recording || '')?.url_path}
 														</a>
 													{:else}
 														<span>
-															No file/url set for {dj_map.get(dj.name)?.recording}
+															No file/url set for {event_dj?.recording}
 														</span>
 													{/if}
 												</HoverCard.Content>

--- a/frontend-svelte-5/src/routes/events/[slug]/export/+page.svelte
+++ b/frontend-svelte-5/src/routes/events/[slug]/export/+page.svelte
@@ -19,7 +19,7 @@
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import * as HoverCard from '$lib/components/ui/hover-card/index.js';
 	import type { File } from '$lib/fileController';
-	import { isImageSource, pushToLog, staticAssetsBase } from '$lib/utils';
+	import { isImageSource, pushToLog } from '$lib/utils';
 	import Label from '$lib/components/ui/label/label.svelte';
 	import { Input } from '$lib/components/ui/input';
 	import Film from 'lucide-svelte/icons/film';
@@ -36,6 +36,8 @@
 	let export_promise = $state(Promise.resolve(false));
 	let export_progress = $state(0);
 	let exporting_state = $state('');
+
+	const staticAssetsBase = `http://${location.hostname}:4004`;
 
 	const exportEvent = () => {
 		exporting = true;
@@ -110,8 +112,7 @@
 													{#if files_map.get(dj_map.get(event_dj.name)?.logo || '')?.file_path}
 														<img
 															class="w-full"
-															src={`${staticAssetsBase}/logos/
-															${files_map.get(dj_map.get(event_dj.name)?.logo || '')?.file_path}`}
+															src={`${staticAssetsBase}/logos/${files_map.get(dj_map.get(event_dj.name)?.logo || '')?.file_path}`}
 															alt="Preview"
 														/>
 														<span>
@@ -170,8 +171,7 @@
 													{#if files_map.get(event_dj?.recording || '')?.file_path}
 														<video
 															controls
-															src={`${staticAssetsBase}/recordings/
-																${files_map.get(event_dj?.recording || '')?.file_path}`}
+															src={`${staticAssetsBase}/recordings/${files_map.get(event_dj?.recording || '')?.file_path}`}
 														>
 															<track kind="captions" />
 														</video>

--- a/frontend-svelte-5/src/routes/events/[slug]/export/+page.ts
+++ b/frontend-svelte-5/src/routes/events/[slug]/export/+page.ts
@@ -25,6 +25,7 @@ export const load: PageLoad = async ({ fetch, params }) => {
 
 	let dj_errors_promise: string[] = [];
 	let promo_errors_promise: string[] = [];
+	let theme_errors: string[] = [];
 
 	if (export_summary.djs.length > 0) {
 		dj_errors_promise = export_summary.event.djs
@@ -64,6 +65,33 @@ export const load: PageLoad = async ({ fetch, params }) => {
 			.filter((error) => error !== undefined);
 	}
 
+	if (export_summary.theme) {
+		if (export_summary.theme.starting_file) {
+			let starting_file = files_map.get(export_summary.theme.starting_file);
+			if (starting_file === undefined) {
+				theme_errors.push(`${export_summary.theme.name}: Invalid file name for Opening.`);
+			} else if (!starting_file.file_path && !starting_file.url_path) {
+				theme_errors.push(`${export_summary.theme.name}: Opening does not have a designated file.`);
+			}
+		}
+		if (export_summary.theme.ending_file) {
+			let ending_file = files_map.get(export_summary.theme.ending_file);
+			if (ending_file === undefined) {
+				theme_errors.push(`${export_summary.theme.name}: Invalid file name for Ending.`);
+			} else if (!ending_file.file_path && !ending_file.url_path) {
+				theme_errors.push(`${export_summary.theme.name}: Ending does not have a designated file.`);
+			}
+		}
+		if (export_summary.theme.overlay_file) {
+			let overlay_file = files_map.get(export_summary.theme.overlay_file);
+			if (overlay_file === undefined) {
+				theme_errors.push(`${export_summary.theme.name}: Invalid file name for Overlay.`);
+			} else if (!overlay_file.file_path && !overlay_file.url_path) {
+				theme_errors.push(`${export_summary.theme.name}: Overlay does not have a designated file.`);
+			}
+		}
+	}
+
 	return {
 		event: export_summary.event,
 		djs: export_summary.djs,
@@ -71,6 +99,7 @@ export const load: PageLoad = async ({ fetch, params }) => {
 		files: export_summary.files,
 		dj_errors_promise,
 		promo_errors_promise,
-		theme: export_summary.theme
+		theme: export_summary.theme,
+		theme_errors
 	};
 };

--- a/frontend-svelte-5/src/routes/events/[slug]/export/+page.ts
+++ b/frontend-svelte-5/src/routes/events/[slug]/export/+page.ts
@@ -37,8 +37,8 @@ export const load: PageLoad = async ({ fetch, params }) => {
 					if (!dj.rtmp_key) return `${dj.name}: Live DJ missing RTMP Key`;
 					if (!dj.rtmp_server) return `${dj.name}: Live DJ missing RTMP Server`;
 				} else {
-					if (!dj.recording) return `${dj.name}: Pre-recorded DJ no recording set.`;
-					const dj_rec_file = files_map.get(dj.recording);
+					if (!event_dj.recording) return `${dj.name}: Pre-recorded DJ no recording set.`;
+					const dj_rec_file = files_map.get(event_dj.recording);
 					if (!dj_rec_file) return `${dj.name}: Pre-recorded DJ Invalid file name for recording.`;
 					if (!dj_rec_file.file_path && !dj_rec_file.url_path)
 						return `${dj.name}: Pre-recorded DJ recording does not have a designated file.`;

--- a/frontend-svelte-5/src/routes/help/+page.svelte
+++ b/frontend-svelte-5/src/routes/help/+page.svelte
@@ -30,10 +30,6 @@
 		{
 			key: 'Stream Key',
 			description: "DJ's unique stream key used when connecting for a live stream."
-		},
-		{
-			key: 'Recording File',
-			description: "File pointing to the local file/url for the DJ's recording."
 		}
 	];
 
@@ -56,6 +52,11 @@
 		{
 			key: 'VJ Name',
 			description: "VJ the DJ's visuals should be credited with."
+		},
+		{
+			key: 'Recording File',
+			description:
+				"File pointing to the local file/url for the DJ's recording. This is set per-event."
 		}
 	];
 
@@ -130,8 +131,8 @@
 			Name` is set.
 		</span>
 		<span class="my-2 flex flex-row">
-			Both the `Logo File` and `Recording File` point to a `File` object, which can be accessed/set
-			by clicking on their buttons.
+			The `Logo File` points to a `File` object, which can be accessed/set by clicking on their
+			buttons.
 		</span>
 		<span class="my-2 flex flex-row">
 			`File` objects can either point to a local file set in the directories specified in the README
@@ -214,9 +215,10 @@
 	</Table.Root>
 	<div class="flex flex-col">
 		<span class="my-2 flex flex-row">
-			Clicking on the ellipses for a DJ's row will give the option to toggle being live, or edit the
-			VJ. There is an edit option, which will open the DJ's page in a new tab. The remove button
-			will remove the DJ from the event, but not delete the DJ.
+			Clicking on the ellipses for a DJ's row will give the option to toggle being live, edit the
+			VJ, or set their recording. When a DJ is set to not live, the recording sidebar will be
+			automatically openened. There is an edit option, which will open the DJ's page in a new tab.
+			The remove button will remove the DJ from the event, but not delete the DJ.
 		</span>
 	</div>
 	<h1 class="scroll-m-20 py-2 text-center text-3xl font-bold tracking-tight lg:text-2xl">

--- a/frontend-svelte-5/src/routes/help/+page.svelte
+++ b/frontend-svelte-5/src/routes/help/+page.svelte
@@ -275,5 +275,8 @@
 			the export succeded, a message telling you the file has been saved should be shown, you are
 			now set to import this file into OBS and the event should be nearly good to go!
 		</span>
+		<span class="my-2 flex flex-row">
+			After exporting, a JSON file will be created in your `LOCAL_EXPORT_PATH`, to be used with the OBS script.
+		</span>
 	</div>
 </div>

--- a/frontend-svelte-5/src/routes/help/+page.svelte
+++ b/frontend-svelte-5/src/routes/help/+page.svelte
@@ -276,7 +276,8 @@
 			now set to import this file into OBS and the event should be nearly good to go!
 		</span>
 		<span class="my-2 flex flex-row">
-			After exporting, a JSON file will be created in your `LOCAL_EXPORT_PATH`, to be used with the OBS script.
+			After exporting, a JSON file will be created in your `LOCAL_EXPORT_PATH`, to be used with the
+			OBS script.
 		</span>
 	</div>
 </div>


### PR DESCRIPTION
Changes the Event's DJs values to be a relationship that contains event specific data, i.e. recordings, is_live, vj, etc.

The main feature of this change is that DJ objects no longer store their recording directly, instead it is set on a per-event basis. This allows the program to not require the user to overwrite the recording for a DJ when adding them to each event. Additionally this will allow better archiving, and ease of adding new features to event DJs by keeping relevant data in the relationship rather than a JSON column.

This includes the following:

- Migration to remove DJ recordings, migrate existing event JSON columns, and introduce the event_dj table
- Updated UI to reflect that DJs no longer have a recording property, and allows setting the recording value directly in the event page.
- Able to view all events the DJ has been added to on the DJ page due to the relational nature of event_djs.
- Updated the /help page to reflect these changes, and updated walkthrough.md to point the user to their current /help for documentation.
- Fixed an issue with the pgsql mount not properly containing the db, and steps to fix this for existing users.
- Updated the backend db handlers for m2m relationship handling, including expanding existing query structures in the case of multiple primary keys.