### PR TITLE
DJ logo and Promo recording file charts bound to instance

### DIFF
--- a/frontend-svelte-5/src/lib/components/ui/dj-logo-objects-sheet/dj-logo-objects-sheet.svelte
+++ b/frontend-svelte-5/src/lib/components/ui/dj-logo-objects-sheet/dj-logo-objects-sheet.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import * as Sheet from '$lib/components/ui/sheet/index.js';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import {
+		updateSingleFile,
+		getSingle,
+		type File,
+		type LocalFile,
+		fileExists,
+		addLogoFile
+	} from '$lib/fileController';
+	import Separator from '$lib/components/ui/separator/separator.svelte';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import LocalFileBrowser from '$lib/components/ui/local-file-browser/local-file-browser.svelte';
+	import { toast } from 'svelte-sonner';
+	import type { DJ } from '$lib/djController';
+
+	type Props = {
+		dj: DJ;
+		submitDjLogoFile: (logo: string | null) => void;
+	};
+
+	let { dj = $bindable(), submitDjLogoFile }: Props = $props();
+
+	const file_type = 'logos';
+
+	let file_sheet_open = $state(false);
+	let selected_file: File = $state({} as File);
+
+	let logo_file: File = $state({} as File);
+	let loading_promise: Promise<File>[] = $state([Promise.resolve({} as File)]);
+
+	let localFileBrowserInstance: LocalFileBrowser;
+
+	const staticAssetsBase = `http://${location.hostname}:4004`;
+
+	const load_dj_logo_file = async () => {
+		const file_promises: Promise<File>[] = [];
+		if (dj.logo !== null) {
+			const logo_file_promise = getSingle(dj.logo);
+			logo_file = await logo_file_promise;
+			file_promises.push(logo_file_promise);
+		} else {
+			logo_file = {
+				name: `${dj.name}-logo`,
+				file_path: '',
+				url_path: '',
+				root: 'LOGOS'
+			};
+		}
+		loading_promise = file_promises;
+	};
+
+	export const openFileSheet = async () => {
+		selected_file = {} as File;
+		file_sheet_open = false;
+		file_sheet_open = true;
+		load_dj_logo_file();
+	};
+
+	const submitFileObjects = async () => {
+		file_sheet_open = false;
+		if ((await fileExists(logo_file.name)) && (logo_file.file_path || logo_file.url_path)) {
+			await updateSingleFile(
+				logo_file.name,
+				logo_file.root,
+				logo_file.file_path,
+				logo_file.url_path
+			);
+		} else if (logo_file.file_path || logo_file.url_path) {
+			await addLogoFile(logo_file.name, logo_file.file_path, logo_file.url_path);
+		} else {
+			logo_file.name = '';
+		}
+
+		toast.success('Logo Updated', {
+			description: 'Updated DJ logo.',
+			action: {
+				label: 'OK',
+				onClick: () => console.info('Yay')
+			}
+		});
+
+		submitDjLogoFile(logo_file.name ? logo_file.name : null);
+	};
+
+	const editLogoFile = async () => {
+		selected_file = logo_file;
+		localFileBrowserInstance.openDialogue();
+	};
+
+	const submitLocalFile = (file_path: string[], local_file: LocalFile) => {
+		let local_path = '';
+		if (file_path.length > 0) {
+			local_path = file_path.join('/') + '/';
+		}
+		local_path += `${local_file.name + local_file.ext}`;
+		selected_file.file_path = local_path;
+	};
+</script>
+
+<Sheet.Root open={file_sheet_open}>
+	<Sheet.Content>
+		<Sheet.Header>
+			<Sheet.Title>
+				<div class="flex flex-row items-center justify-between">
+					Setup DJ Logo for {dj.name}
+				</div>
+			</Sheet.Title>
+			<Sheet.Description>
+				<p class="py-2 text-center text-muted-foreground">Logo</p>
+				<div class="flex w-full flex-row justify-between gap-1.5">
+					<p class="my-auto w-full text-center text-muted-foreground">Local File</p>
+					<Button class="w-full" variant="secondary" onclick={editLogoFile}>Edit</Button>
+					<Button class="w-full" variant="destructive" onclick={() => (logo_file.file_path = null)}
+						>Unset</Button
+					>
+				</div>
+				<div class="flex flex-row items-center justify-between pt-4">
+					<Input class="w-80" type="text" placeholder="URL" bind:value={logo_file.url_path} />
+				</div>
+				<Separator class="my-4"></Separator>
+				{#if logo_file.file_path}
+					<img
+						class="w-full"
+						src={`${staticAssetsBase}/logos/${logo_file.file_path}`}
+						alt="Preview"
+					/>
+				{:else if logo_file.url_path}
+					<img class="w-full" src={logo_file.url_path} alt="Preview" />
+				{/if}
+				<Separator class="my-4"></Separator>
+				<div class="my-1.5 flex w-full flex-row justify-between gap-1.5">
+					<Button class="w-full" onclick={submitFileObjects}>Submit</Button>
+				</div>
+			</Sheet.Description>
+		</Sheet.Header>
+	</Sheet.Content>
+</Sheet.Root>
+
+<LocalFileBrowser {file_type} {submitLocalFile} bind:this={localFileBrowserInstance} />

--- a/frontend-svelte-5/src/lib/components/ui/local-file-browser/local-file-browser.svelte
+++ b/frontend-svelte-5/src/lib/components/ui/local-file-browser/local-file-browser.svelte
@@ -191,8 +191,8 @@
 				</div>
 			</Dialog.Title>
 			<Dialog.Description>
-				<div class="flex flex-col items-center justify-between md:flex-row gap-4">
-					<div class="table-container h-96 overflow-y-auto md:h-[40vh] basis-1/2 w-full">
+				<div class="flex flex-col items-center justify-between gap-4 md:flex-row">
+					<div class="table-container h-96 w-full basis-1/2 overflow-y-auto md:h-[40vh]">
 						<Table.Root>
 							<Table.Header>
 								<Table.Row>
@@ -222,19 +222,19 @@
 							</Table.Body>
 						</Table.Root>
 					</div>
-					<div class="mx-auto basis-1/2 h-96 md:h-[40vh]">
+					<div class="mx-auto h-96 basis-1/2 md:h-[40vh]">
 						{#if file_browser_selected_file?.name && !file_browser_selected_file.is_dir}
 							{#if isImageSource(file_browser_preview_path)}
 								<img
-									class="object-scale-down w-full h-full"
+									class="h-full w-full object-scale-down"
 									src={file_browser_preview_path}
 									alt="Preview"
 								/>
 							{:else}
 								<video
-									class="object-scale-down w-full h-full"
-									controls src={file_browser_preview_path}
-								><track kind="captions" /></video
+									class="h-full w-full object-scale-down"
+									controls
+									src={file_browser_preview_path}><track kind="captions" /></video
 								>
 							{/if}
 						{/if}

--- a/frontend-svelte-5/src/lib/components/ui/promo-file-objects-sheet/promo-file-objects-sheet.svelte
+++ b/frontend-svelte-5/src/lib/components/ui/promo-file-objects-sheet/promo-file-objects-sheet.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import * as Sheet from '$lib/components/ui/sheet/index.js';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import {
+		updateSingleFile,
+		getSingle,
+		type File,
+		type LocalFile,
+		fileExists,
+		addLogoFile,
+		addRecordingFile
+	} from '$lib/fileController';
+	import Separator from '$lib/components/ui/separator/separator.svelte';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import LocalFileBrowser from '$lib/components/ui/local-file-browser/local-file-browser.svelte';
+	import { toast } from 'svelte-sonner';
+	import type { DJ } from '$lib/djController';
+	import type { Promotion } from '$lib/promotionsController';
+
+	type Props = {
+		promo: Promotion;
+		submitPromoRecordingFile: (promo: string | null) => void;
+	};
+
+	let { promo = $bindable(), submitPromoRecordingFile }: Props = $props();
+
+	const file_type = 'recordings';
+
+	let file_sheet_open = $state(false);
+	let selected_file: File = $state({} as File);
+
+	let promo_file: File = $state({} as File);
+	let loading_promise: Promise<File>[] = $state([Promise.resolve({} as File)]);
+
+	let localFileBrowserInstance: LocalFileBrowser;
+
+	const staticAssetsBase = `http://${location.hostname}:4004`;
+
+	const load_promo_recording_file = async () => {
+		const file_promises: Promise<File>[] = [];
+		if (promo.promo_file !== null) {
+			const recording_file_promise = getSingle(promo.promo_file);
+			promo_file = await recording_file_promise;
+			file_promises.push(recording_file_promise);
+		} else {
+			promo_file = {
+				name: `${promo.name}-recording`,
+				file_path: '',
+				url_path: '',
+				root: 'RECORDINGS'
+			};
+		}
+		loading_promise = file_promises;
+	};
+
+	export const openFileSheet = async () => {
+		selected_file = {} as File;
+		file_sheet_open = false;
+		file_sheet_open = true;
+		load_promo_recording_file();
+	};
+
+	const submitFileObjects = async () => {
+		file_sheet_open = false;
+		if ((await fileExists(promo_file.name)) && (promo_file.file_path || promo_file.url_path)) {
+			await updateSingleFile(
+				promo_file.name,
+				promo_file.root,
+				promo_file.file_path,
+				promo_file.url_path
+			);
+		} else if (promo_file.file_path || promo_file.url_path) {
+			await addRecordingFile(promo_file.name, promo_file.file_path, promo_file.url_path);
+		} else {
+			promo_file.name = '';
+		}
+
+		toast.success('Promotion Updated', {
+			description: 'Updated Promotion recording values.',
+			action: {
+				label: 'OK',
+				onClick: () => console.info('Yay')
+			}
+		});
+
+		submitPromoRecordingFile(promo_file.name ? promo_file.name : null);
+	};
+
+	const editPromoFile = async () => {
+		selected_file = promo_file;
+		localFileBrowserInstance.openDialogue();
+	};
+
+	const submitLocalFile = (file_path: string[], local_file: LocalFile) => {
+		let local_path = '';
+		if (file_path.length > 0) {
+			local_path = file_path.join('/') + '/';
+		}
+		local_path += `${local_file.name + local_file.ext}`;
+		selected_file.file_path = local_path;
+	};
+</script>
+
+<Sheet.Root open={file_sheet_open}>
+	<Sheet.Content>
+		<Sheet.Header>
+			<Sheet.Title>
+				<div class="flex flex-row items-center justify-between">
+					Setup Promotion recording for {promo.name}
+				</div>
+			</Sheet.Title>
+			<Sheet.Description>
+				<p class="py-2 text-center text-muted-foreground">Promotion</p>
+				<div class="flex w-full flex-row justify-between gap-1.5">
+					<p class="my-auto w-full text-center text-muted-foreground">Local File</p>
+					<Button class="w-full" variant="secondary" onclick={editPromoFile}>Edit</Button>
+					<Button class="w-full" variant="destructive" onclick={() => (promo_file.file_path = null)}
+						>Unset</Button
+					>
+				</div>
+				<div class="flex flex-row items-center justify-between pt-4">
+					<Input class="w-80" type="text" placeholder="URL" bind:value={promo_file.url_path} />
+				</div>
+				<Separator class="my-4"></Separator>
+				{#if promo_file.file_path}
+					<video controls src={`${staticAssetsBase}/recordings/${promo_file.file_path}`}
+						><track kind="captions" /></video
+					>
+				{:else if promo_file.url_path}
+					<video controls src={promo_file.url_path}><track kind="captions" /></video>
+				{/if}
+				<Separator class="my-4"></Separator>
+				<div class="my-1.5 flex w-full flex-row justify-between gap-1.5">
+					<Button class="w-full" onclick={submitFileObjects}>Submit</Button>
+				</div>
+			</Sheet.Description>
+		</Sheet.Header>
+	</Sheet.Content>
+</Sheet.Root>
+
+<LocalFileBrowser {file_type} {submitLocalFile} bind:this={localFileBrowserInstance} />

--- a/frontend-svelte-5/src/lib/fileController.ts
+++ b/frontend-svelte-5/src/lib/fileController.ts
@@ -144,8 +144,8 @@ export const getThemePermissions = async (sub_dirs: string[]) => {
  */
 export const addLogoFile = async (
 	name: string,
-	file_path?: string,
-	url_path?: string
+	file_path?: string | null,
+	url_path?: string | null
 ): Promise<File> => {
 	const body = {
 		name: name,

--- a/frontend-svelte-5/src/routes/djs/[slug]/+page.svelte
+++ b/frontend-svelte-5/src/routes/djs/[slug]/+page.svelte
@@ -3,11 +3,10 @@
 	import { goto, afterNavigate } from '$app/navigation';
 	import { base } from '$app/paths';
 	import DjTable from './dj-table.svelte';
-	import { type File } from '$lib/fileController';
-	import FileObjectsSheet from '$lib/components/ui/file-objects-sheet/file-objects-sheet.svelte';
 	import { toast } from 'svelte-sonner';
 	import { deleteSingle, updateSingle } from '$lib/djController';
 	import { pushToLog } from '$lib/utils';
+	import DjLogoObjectsSheet from '$lib/components/ui/dj-logo-objects-sheet/dj-logo-objects-sheet.svelte';
 
 	let previousPage: string = base;
 
@@ -18,9 +17,8 @@
 	let { data }: PageProps = $props();
 	let dj = $state(data.dj);
 	let events = data.events;
-	let file_type: 'logos' | 'recordings' = $state('logos');
 
-	let fileObjectSheetInstance: FileObjectsSheet;
+	let djLogoObjectSheetInstance: DjLogoObjectsSheet;
 
 	const submitChanges = () => {
 		updateSingle(dj.name, dj.logo, dj.rtmp_server, dj.rtmp_key, dj.public_name, dj.discord_id)
@@ -84,12 +82,11 @@
 	};
 
 	const selectLogo = () => {
-		file_type = 'logos';
-		fileObjectSheetInstance.openFileSheet();
+		djLogoObjectSheetInstance.openFileSheet();
 	};
 
-	const submitFile = (selected_file: File) => {
-		dj.logo = selected_file.name;
+	const submitDjLogoFile = (logo: string | null) => {
+		dj.logo = logo;
 	};
 
 	const unsetLogoFile = () => {
@@ -103,4 +100,4 @@
 
 <DjTable bind:dj {events} {submitChanges} {deleteDj} {selectLogo} {unsetLogoFile} />
 
-<FileObjectsSheet bind:dj {file_type} {submitFile} bind:this={fileObjectSheetInstance} />
+<DjLogoObjectsSheet bind:dj {submitDjLogoFile} bind:this={djLogoObjectSheetInstance} />

--- a/frontend-svelte-5/src/routes/promotions/[slug]/+page.svelte
+++ b/frontend-svelte-5/src/routes/promotions/[slug]/+page.svelte
@@ -2,12 +2,11 @@
 	import type { PageProps } from './$types';
 	import { goto, afterNavigate } from '$app/navigation';
 	import { base } from '$app/paths';
-	import { type File } from '$lib/fileController';
-	import FileObjectsSheet from '$lib/components/ui/file-objects-sheet/file-objects-sheet.svelte';
 	import { toast } from 'svelte-sonner';
 	import { deleteSingle, updateSingle } from '$lib/promotionsController';
 	import PromotionTable from './promotion-table.svelte';
 	import { pushToLog } from '$lib/utils';
+	import PromoFileObjectsSheet from '$lib/components/ui/promo-file-objects-sheet/promo-file-objects-sheet.svelte';
 
 	let previousPage: string = base;
 
@@ -17,9 +16,8 @@
 
 	let { data }: PageProps = $props();
 	let promo = $state(data.promo);
-	const file_type = 'recordings';
 
-	let fileObjectSheetInstance: FileObjectsSheet;
+	let promoFileObjectSheetInstance: PromoFileObjectsSheet;
 
 	const submitChanges = () => {
 		updateSingle(promo.name, promo.promo_file)
@@ -83,11 +81,11 @@
 	};
 
 	const selectFile = () => {
-		fileObjectSheetInstance.openFileSheet();
+		promoFileObjectSheetInstance.openFileSheet();
 	};
 
-	const submitFile = (selectedFile: File) => {
-		promo.promo_file = selectedFile.name;
+	const submitPromoRecordingFile = (promoFile: string | null) => {
+		promo.promo_file = promoFile;
 	};
 
 	const unsetFile = () => {
@@ -101,4 +99,8 @@
 
 <PromotionTable bind:promo {submitChanges} {deletePromotion} {selectFile} {unsetFile} />
 
-<FileObjectsSheet bind:promo {file_type} {submitFile} bind:this={fileObjectSheetInstance} />
+<PromoFileObjectsSheet
+	bind:promo
+	{submitPromoRecordingFile}
+	bind:this={promoFileObjectSheetInstance}
+/>


### PR DESCRIPTION
Changed DJ logos and Promotion recordings to bound to their instance, so that when editing their fields the file naming and creation is handled by the UI logic. This mirrors how file objects are handled in event_djs and should reduce the # of clicks for the same functionality.

The 2 new file objects sheets can be rolled together with the existing event_djs's sheet later on for a unified bound file objects sheet to compliment the existing generalized one.